### PR TITLE
Remove `prove_from_known_elabs`; migrate callers to `prove_by_lang_db`

### DIFF
--- a/src/Pyrosome/Elab/ElabCompilers.v
+++ b/src/Pyrosome/Elab/ElabCompilers.v
@@ -140,6 +140,17 @@ End WithModel.
     
 End Extension.
 
+Lemma elab_preserving_compiler_embed cmp_pre tgt cmp ecmp src tgt'
+    : elab_preserving_compiler cmp_pre tgt cmp ecmp src ->
+      incl tgt tgt' ->
+      elab_preserving_compiler cmp_pre tgt' cmp ecmp src.
+Proof.
+  induction 1; basic_goal_prep; constructor.
+  6:eapply eq_sort_lang_monotonicity; now eauto.
+  7:eapply eq_term_lang_monotonicity; now eauto.
+  all:basic_core_firstorder_crush.
+Qed.
+Hint Resolve elab_preserving_compiler_embed : auto_elab.
 
 End WithVar.
 
@@ -165,13 +176,13 @@ End WithVar.
 (*
   TODO: remove dependency on Matches or no?
  *)
-From Pyrosome.Tools Require Import Matches.
+From Pyrosome.Tools Require Import Matches Resolution.
 
 Ltac setup_elab_compiler :=
   match goal with
   | |- elab_preserving_compiler _ ?tgt ?cmp ?ecmp ?src =>
         rewrite (as_nth_tail cmp); rewrite (as_nth_tail ecmp); rewrite (as_nth_tail src);
-      assert (wf_lang tgt) by prove_from_known_elabs
+      assert (wf_lang tgt) by prove_by_lang_db
   end; break_preserving.
 
 Tactic Notation "cleanup_elab_after" tactic(tc) :=

--- a/src/Pyrosome/Lang/Multilanguages.v
+++ b/src/Pyrosome/Lang/Multilanguages.v
@@ -170,7 +170,7 @@ Ltac solve_parameterize_wrapper l := (* deleted comments in equivalent code from
   eapply parameterize_lang_preserving_ext;
     try typeclasses eauto;
     [repeat t';  constructor
-    | now prove_from_known_elabs..
+    | now prove_by_lang_db..
     | vm_compute; exact I].
 
 Definition typed_bool_parameterized := parameterize_wrapper typed_bool. 
@@ -445,7 +445,7 @@ Proof.
   - eapply parameterize_lang_preserving_ext;
     try typeclasses eauto;
     [repeat t';  constructor (*TODO: include in t'*)
-    | now prove_from_known_elabs..
+    | now prove_by_lang_db..
     | vm_compute; exact I].
   - cbv; reflexivity. 
 Qed. 
@@ -528,7 +528,7 @@ Proof.
   - eapply parameterize_lang_preserving_ext;
     try typeclasses eauto;
     [repeat t';  constructor (*TODO: include in t'*)
-    | now prove_from_known_elabs..
+    | now prove_by_lang_db..
     | vm_compute; exact I].
   - cbv; reflexivity. 
 Qed. 
@@ -611,7 +611,7 @@ Proof.
   - eapply parameterize_lang_preserving_ext;
     try typeclasses eauto;
     [repeat t';  constructor (*TODO: include in t'*)
-    | now prove_from_known_elabs..
+    | now prove_by_lang_db..
     | vm_compute; exact I].
   - cbv; reflexivity. 
 Qed. 
@@ -707,7 +707,7 @@ Proof.
   - eapply parameterize_lang_preserving_ext;
     try typeclasses eauto;
     [repeat t';  constructor (*TODO: include in t'*)
-    | now prove_from_known_elabs..
+    | now prove_by_lang_db..
     | vm_compute; exact I].
   - cbv; reflexivity. 
 Qed. 
@@ -834,7 +834,7 @@ Proof.
   - eapply parameterize_lang_preserving_ext;
     try typeclasses eauto;
     [repeat t';  constructor (*TODO: include in t'*)
-    | now prove_from_known_elabs..
+    | now prove_by_lang_db..
     | vm_compute; exact I].
   - cbv; reflexivity. 
 Qed. 
@@ -1140,7 +1140,7 @@ Proof. Abort.
 (*
     (* OLD TACTICS (for some reason this doesn't work now?) *)
     unfold polymorphic_shared_fragment. 
-    apply id_compiler_preserving; prove_from_known_elabs. 
+    apply id_compiler_preserving; prove_by_lang_db.
     typeclasses eauto.
 Qed.
 Hint Resolve polymorphic_shared_fragment_identity_compiler_preserving : auto_elab.

--- a/src/Pyrosome/Lang/PolyCompilers.v
+++ b/src/Pyrosome/Lang/PolyCompilers.v
@@ -58,7 +58,7 @@ Proof.
   eapply parameterize_lang_preserving_ext;
     try typeclasses eauto;
     [repeat t';  constructor (*TODO: include in t'*)
-    | now prove_from_known_elabs..
+    | now prove_by_lang_db..
     | vm_compute; exact I].
 Qed.
 #[local] Definition stlc_parameterized_entry :=

--- a/src/Pyrosome/Tools/CompilerTools.v
+++ b/src/Pyrosome/Tools/CompilerTools.v
@@ -7,7 +7,7 @@ Open Scope string.
 Open Scope list.
 From Utils Require Import Utils.
 From Pyrosome Require Import Theory.Core Tools.AllConstructors Compilers.Compilers
-  Elab.Elab Elab.ElabCompilers.
+  Elab.Elab.
 Import Core.Notations.
 (*TODO: repackage this in compilers*)
 Import CompilerDefs.Notations.
@@ -31,19 +31,6 @@ Section WithVar.
   Notation rule := (@rule V).
   Notation lang := (@lang V).
   Notation compiler := (@compiler V).
-
-Lemma elab_preserving_compiler_embed cmp_pre tgt cmp ecmp src tgt'
-    : elab_preserving_compiler cmp_pre tgt cmp ecmp src ->
-      incl tgt tgt' ->
-      elab_preserving_compiler cmp_pre tgt' cmp ecmp src.
-Proof.
-  induction 1; basic_goal_prep; constructor.
-  6:eapply eq_sort_lang_monotonicity; now eauto.
-  7:eapply eq_term_lang_monotonicity; now eauto.
-  all:basic_core_firstorder_crush.
-Qed.
-Hint Resolve elab_preserving_compiler_embed : auto_elab.
-
 
 Lemma strengthen_named_list_lookup {A} (cmp : named_list A) n
   : forall cmp', incl cmp cmp' ->

--- a/src/Pyrosome/Tools/EGraph/Automation.v
+++ b/src/Pyrosome/Tools/EGraph/Automation.v
@@ -25,7 +25,7 @@ Import StateMonad.
 Import StringInstantiation.
 
 
-From Pyrosome Require Import Tools.Matches.
+From Pyrosome Require Import Tools.Matches Tools.Resolution.
 
 
 Definition print_egraph {X} (g : instance string string string_trie_map string_trie_map string_list_trie_map X) :=
@@ -82,7 +82,7 @@ Ltac by_reduction' reversible inj_rules :=
   try reduce;
    *)
     apply (egraph_sound 100 100 100 100 filter_rules reversible inj_rules);
-    [prove_from_known_elabs| | | | flagged_exact I].
+    [prove_by_lang_db| | | | flagged_exact I].
 
 
 (* TODO: plug inj_rules into tactics *)

--- a/src/Pyrosome/Tools/EGraph/ComputeWf.v
+++ b/src/Pyrosome/Tools/EGraph/ComputeWf.v
@@ -764,7 +764,7 @@ Notation wf_args l :=
         let c' := eval vm_compute in c in
         let t' := eval vm_compute in t in
         change_no_check (wf_sort l c' t'); eapply wf_sort_by
-  | [|- wf_lang _] => solve[prove_from_known_elabs]
+  | [|- wf_lang _] => solve[prove_by_lang_db]
   (*Don't use vm_compute here*)
   | [|- _ = _] => compute; reflexivity
   end.

--- a/src/Pyrosome/Tools/Interactive.v
+++ b/src/Pyrosome/Tools/Interactive.v
@@ -6,6 +6,7 @@ Open Scope list.
 From Utils Require Import Utils.
 From Pyrosome Require Import Theory.Core Elab.Elab
   Tools.Matches
+  Tools.Resolution
   Tools.EGraph.ComputeWf
   Tools.EGraph.TypeInference
   Elab.PreTerm Elab.PreRule.
@@ -72,5 +73,5 @@ Ltac setup_lang_interactive :=
       (* So that l is fully evaluated *)
       let l' := open_constr:(_ : lang _) in
       replace l with l';[|shelve];
-      assert (wf_lang base) by prove_from_known_elabs
+      assert (wf_lang base) by prove_by_lang_db
   end.

--- a/src/Pyrosome/Tools/Matches.v
+++ b/src/Pyrosome/Tools/Matches.v
@@ -13,7 +13,7 @@ Open Scope list.
 From Utils Require Import Utils Monad.
 (*TODO: deprecate computewf at some point (in favor of more general tactic based on reduction proofs) *)
 From Pyrosome Require Import Theory.Core Elab.Elab Tools.ComputeWf Tools.Linter
-  Proof.TreeProofs Tools.Int63Renaming.
+  Proof.TreeProofs Tools.Int63Renaming Tools.Resolution.
 
 Import Core.Notations.
 
@@ -561,15 +561,12 @@ Ltac prove_ident_from_known_elabs :=
   | auto with utils
   | compute_all_fresh].
 
-#[deprecated(note="Use `Tools.Resolution.prove_by_lang_db` instead")]
-Ltac prove_from_known_elabs := fail "Use `Tools.Resolution.prove_by_lang_db` instead".
-
 Ltac term_cong :=
   eapply term_con_congruence;
   [ solve_in
   (*| solve_len_eq*)
   | try (right; vm_compute; reflexivity)
-  | solve[prove_from_known_elabs]
+  | solve[prove_by_lang_db]
   | repeat match goal with [|- eq_args _ _ _ _] =>
                            simple apply eq_args_nil
                            || simple eapply eq_args_cons2
@@ -625,7 +622,7 @@ Ltac compute_wf_subjects :=
         let c' := eval vm_compute in c in
         let t' := eval vm_compute in t in
         change_no_check (wf_sort l c' t'); eapply wf_sort_by
-  | [|- wf_lang _] => solve[prove_from_known_elabs]
+  | [|- wf_lang _] => solve[prove_by_lang_db]
   (*Don't use vm_compute here*)
   | [|- _ = _] => compute; reflexivity
   end.
@@ -919,7 +916,7 @@ Ltac split_rule_elab :=
   | compute; reflexivity
   | apply (use_compute_fresh _); compute; reflexivity |
   (*fail 2 since this will be used in a repeat *)
-  | solve [ prove_from_known_elabs ] || fail 2 "Could not prove base language wf" |].
+  | solve [ prove_by_lang_db ] || fail 2 "Could not prove base language wf" |].
 
 Ltac setup_elab_lang :=
   lazymatch goal with

--- a/src/Pyrosome/Tools/Resolution.v
+++ b/src/Pyrosome/Tools/Resolution.v
@@ -896,6 +896,3 @@ Ltac prove_by_cmp_db :=
   apply (cmp_wf_in_db_correct _ _ _ _ (proj2_sig (db_append_cmp_list (V:=string) db)));
   flagged_exact I.
 
-(*TODO: get rid of this *)
-From Pyrosome.Tools Require Matches.
-Ltac Matches.prove_from_known_elabs ::= prove_by_lang_db.


### PR DESCRIPTION
Remove `prove_from_known_elabs` in favor of the newer `prove_by_lang_db`. This completes the migration that had been in-progress.