### PR TITLE
LinearCPS: fix linear_cps_preserving Qed-hang via composite proof

### DIFF
--- a/src/Pyrosome/Lang/LinearCPS.v
+++ b/src/Pyrosome/Lang/LinearCPS.v
@@ -337,14 +337,6 @@ Ltac csub_normalize cs :=
   | _ => cs
   end.
 
-Ltac csub_assoc cs :=
-  match cs with
-  | {{e #"csub" {?G} {?G'} {?H} {?H'}
-      (#"csub" {?G1} {?G1'} {?G2} {?G2'} {?g1} {?g2}) {?h} }} =>
-    constr:({{e #"csub" {G1} {G1'} (#"conc" {G2} {H}) (#"conc" {G2'} {H'})
-      {g1} (#"csub" {G2} {G2'} {H} {H'} {g2} {h}) }})
-  end.
-
 Ltac exch_invert :=
   compute_eq_compilation;
   eapply eq_term_conv;
@@ -362,6 +354,14 @@ Ltac unapply l r :=
 Ltac trans t :=
   eapply eq_term_trans;
   [> t | .. ].
+
+Ltac eredex_general l r :=
+  eapply eq_term_conv;
+      [>
+        eapply eq_term_trans;
+        [> term_cong | .. ];
+        [> .. | eredex_steps_with l r ] |
+        .. ].
 
 (* left-assoc cmp of three subs -> split into two cmps *)
 Ltac reassoc_cmp4 :=
@@ -550,14 +550,6 @@ Optimize Heap.
     all: try solve_wf_term.
     shelve.
   }
-
-  Ltac eredex_general l r :=
-    eapply eq_term_conv;
-        [>
-          eapply eq_term_trans;
-          [> term_cong | .. ];
-          [> .. | eredex_steps_with l r ] |
-          .. ].
 
   compute_eq_compilation.
 

--- a/src/Pyrosome/Lang/LinearCPS.v
+++ b/src/Pyrosome/Lang/LinearCPS.v
@@ -217,18 +217,172 @@ Definition linear_cps_def : compiler :=
   end.
 
 
-Ltac solve_wf_term :=
-  first [eapply wf_term_by';
-         [> solve_in | solve_wf_args
-         | first [left; reflexivity | right; sort_cong; by_reduction; t'] ]
-        | eapply wf_term_var; solve_in]
-    with solve_wf_args :=
-    first [apply wf_args_nil | constructor; [> solve_wf_term | solve_wf_args ]].
+From Pyrosome.Tools Require Import UnElab.
+From Pyrosome.Proof Require Import TreeProofs.
+Ltac by_reduction := Matches.by_reduction.
+Ltac reduce_by l r :=
+  eapply eq_term_trans;
+  [> eredex_steps_with l r | ..].
 
-Ltac s :=
+Ltac normalize_env_step :=
+  compute_eq_compilation;
   match goal with
+  | |- eq_term _ _ {{s #"env"}} {{e #"conc" #"emp" {_} }} _ =>
+    reduce_by linear_value_subst "conc_emp_l"
+  | |- eq_term _ _ {{s #"env"}} {{e #"conc" {_} #"emp" }} _ =>
+    reduce_by linear_value_subst "conc_emp_r"
+  | |- eq_term _ _ {{s #"env"}} {{e #"conc" (#"conc" {_} {_}) {_} }} _ =>
+    reduce_by linear_value_subst "conc_assoc"
+  | |- eq_term _ _ {{s #"env"}} {{e #"conc" {_} {_} }} _ => term_cong
+  | _ => term_refl
+  end.
+
+Ltac normalize_env :=
+  eapply eq_term_trans;
+  [> repeat normalize_env_step; term_refl | .. ].
+
+
+Ltac simplify_wf_term :=
+  try unfold Model.wf_term;
+  match goal with
+  | |- wf_term ?l ?c ?e ?t =>
+      let c' := eval vm_compute in c in
+      let e' := eval vm_compute in e in
+      let t' := eval vm_compute in t in
+          change_no_check (wf_term l c' e' t')
+  end.
+
+      (* Ltac eredex_steps_with' lang name :=
+  let mr := eval vm_compute in (named_list_lookup_err lang name) in
+      lazymatch mr with
+      | Some (term_eq_rule ?c ?e1p ?e2p ?tp) =>
+        lazymatch goal with
+        | [|- @eq_term ?V _ ?l ?c' ?t ?e1 ?e2] =>
+          let s := open_constr:(_:subst) in
+          first [unify_var_names V s c | fail 2 "could not unify var names"];
+          idtac t tp e1 e1p e2 e2p;
+          first [ replace (eq_term l c' t e1 e2)
+                    with (@eq_term V _ l c' tp[/s/] e1p[/s/] e2p[/s/])
+                  (* [| f_equal; vm_compute; reflexivity ]
+                | fail 2 "could not replace with subst"];
+          eapply (@eq_term_subst V _ l c' s s c);
+          [eapply (@eq_term_by V _ l c name tp e1p e2p);
+           try solve [cleanup_auto_elab]
+          | eapply eq_subst_refl; try solve [cleanup_auto_elab]
+          | try solve [cleanup_auto_elab] *)
+          ]
+        end
+      | None =>
+        fail 100 "rule not found in lang"
+      end. *)
+
+Ltac solve_wf_term := first [eapply wf_term_by';
+  [> solve_in | solve_wf_args | first [left; reflexivity | right; solve_sort] ]
+  | eapply wf_term_var; solve_in]
+with solve_wf_args :=
+  first [apply wf_args_nil | constructor; [> solve_wf_term | solve_wf_args ]]
+with env_eq :=
+  compute_eq_compilation;
+  normalize_env;
+  eapply eq_term_sym;
+  normalize_env;
+  apply eq_term_refl;
+  solve_wf_term
+with solve_sort := sort_cong; [> env_eq .. ].
+
+Ltac solve_wf_subst :=
+  repeat (eapply wf_subst_cons; [> .. | solve_wf_term ]);
+  eapply wf_subst_nil.
+
+Ltac conv_steps_with l r :=
+  eapply eq_term_conv;
+  [> eredex_steps_with l r | solve_sort].
+
+Ltac thru_steps_with l r :=
+  first [ conv_steps_with l r |
+    term_cong; try compute_eq_compilation;
+    first [
+      left; solve_sort |
+      thru_steps_with l r |
+      term_refl l r |
+      env_eq ] ].
+
+Ltac lhs_thru_steps_with l r :=
+  eapply eq_term_trans;
+  [> thru_steps_with l r | .. ].
+
+
+Ltac make_pf :=
+  lazymatch goal with
+    | [|- eq_term ?l ?c' ?t ?e1 ?e2] =>
+        (*TODO: 100 is a magic number; make it an input*)
+        let x := eval compute in (step_term_V l c' 100 e1 t) in
+          eapply pf_checker_sound with(p:=x);
+          [typeclasses eauto | assumption |]
+  end.
+
+Ltac reduce_exch :=
+  eapply eq_term_trans;
+  [> term_cong; try compute_eq_compilation;
+  lazymatch goal with
+  | [|- _ \/ _ ] => right; reflexivity
+  | [|- eq_term _ _ {{s #"env"}} _ _ ] => env_eq
+  | [|- eq_term _ _ {{s #"sub" {_} {_} }}
+      {{e #"cmp" {_} {_} {_}
+        (#"csub" {?G1} {?G2} {?H1} {?H2} {?g} {?h} )
+        (#"exch" {?G2} {?H2}) }} _ ] =>
+        eapply eq_term_conv;
+        [> eapply eq_term_trans;
+          [> term_cong; [> .. | term_refl ] |
+            compute_eq_compilation;
+            eredex_steps_with linear_value_subst "exch_cmp";
+            instantiate (8 := {{e #"id" #"emp" }});
+            instantiate (7 := h);
+            instantiate (6 := g);
+            instantiate (5 := {{e #"id" #"emp" }});
+            solve_wf_subst ] |
+          solve_sort ]
+  | [|- eq_term _ _ _ _ _ ] => term_refl
+  end;
+  by_reduction | reduce ].
+
+Ltac blk_cmp :=
+  eapply eq_term_trans;
+  [> lazymatch goal with
+    | [|- eq_term _ _ _ {{e #"blk_subst" {_} {_}
+      (#"cmp" {?G1} {?G2} {?G3} {?g1} {?g2})
+      {?e} }} _ ] =>
+      instantiate (1:=
+        {{e #"blk_subst" {G1} {G2} {g1}
+            (#"blk_subst" {G2} {G3} {g2} {e})}});
+      apply eq_term_sym;
+      eapply eq_term_conv;
+      [> eredex_steps_with linear_block_subst "blk_subst_cmp";
+        solve_wf_subst
+      | solve_sort]
+    end
+  | .. ].
+
+Ltac shelve_env :=
+  eapply eq_term_trans;
+  [> term_cong; try compute_eq_compilation;
+  lazymatch goal with
+  | [|- _ \/ _ ] => shelve
+  | [|- eq_term _ _ {{s #"env"}} _ _ ] => shelve
+  | [|- eq_term _ _ _ _ _ ] => term_refl
+  end
+  | .. ].
+
+Ltac apply_rule l r :=
+  eapply eq_term_trans;
+  [> shelve_env; eapply eq_term_conv;
+    [> eredex_steps_with l r | solve_sort ]
+  | ..].
+ Ltac s :=
+   match goal with
   | [|- fresh _ _ ]=> compute_fresh
   | [|- sublist _ _ ]=> compute_sublist
+   (* TODO: if this works, use this pattern for other typeclass occurances *)
   | [|- In _ _ ]=> solve_in
   | [|- len_eq _ _] => econstructor
   | [|-elab_sort _ _ _ _] => eapply elab_sort_by
@@ -237,8 +391,86 @@ Ltac s :=
   | [|-elab_term _ _ _ _ _] => eapply elab_term_by' || eapply elab_term_var
   | [|-wf_term _ _ _ _] => solve_wf_term || shelve
   | [|-elab_rule _ _ _] => econstructor
+  (* | [|- ?eq \/ ?seq ] => tryif (has_evar ?Goal) then shelve else (left; reflexivity) || shelve *)
   | [|- _ = _] => compute; reflexivity
+ end.
+
+Ltac lefl := left; reflexivity.
+
+Ltac reduce_to e :=
+  eapply eq_term_trans;
+  [> instantiate (1:=e); try by_reduction | .. ].
+
+Ltac break_cmp :=
+  term_cong; cycle 1;
+  [> term_refl | term_refl | term_refl |
+      compute_eq_compilation | compute_eq_compilation |
+      left; solve_sort ].
+
+Ltac normalize_perm :=
+  lazymatch goal with
+  | [|- eq_term _ _ {{s #"sub" {?s1} {?s2} }} ?e _ ] =>
+    lazymatch e with
+    | {{e #"cmp" {_} {_} {_} {_} {_} }} =>
+      eapply eq_term_trans;
+      [> break_cmp;
+        [> normalize_perm | term_refl ] |
+        compute_eq_compilation ]
+    | _ => term_refl
+    end
   end.
+
+Ltac csub_join G G' H H' g h :=
+  match h with
+  | {{e #"csub" {?H1} {?H1'} {?H2} {?H2'} {?h1} {?h2} }} =>
+    csub_join
+      {{e #"conc" {G} {H1} }} {{e #"conc" {G'} {H1'} }} H2 H2'
+      {{e #"csub" {g} {h1} }} h2
+  | _ => constr:({{e #"csub" {G} {G'} {H} {H'} {g} {h} }})
+  end.
+
+Ltac csub_normalize cs :=
+  match cs with
+  | {{e #"csub" {?G} {?G'} {?H} {?H'} {?g} {?h} }} =>
+    let g' := csub_normalize g in
+    let h' := csub_normalize h in
+    csub_join G G' H H' g' h'
+  | {{e #"id" (#"conc" {?G} {?H}) }} =>
+    csub_normalize {{e #"csub" {G} {G} {H} {H} (#"id" {G}) (#"id" {H}) }}
+  | _ => cs
+  end.
+
+Ltac csub_assoc cs :=
+  match cs with
+  | {{e #"csub" {?G} {?G'} {?H} {?H'}
+      (#"csub" {?G1} {?G1'} {?G2} {?G2'} {?g1} {?g2}) {?h} }} =>
+    constr:({{e #"csub" {G1} {G1'} (#"conc" {G2} {H}) (#"conc" {G2'} {H'})
+      {g1} (#"csub" {G2} {G2'} {H} {H'} {g2} {h}) }})
+  end.
+
+Ltac exch_invert :=
+  compute_eq_compilation;
+  eapply eq_term_conv;
+  [> eapply eq_term_trans;
+    [> term_cong; [> .. | term_refl ] |
+      compute_eq_compilation;
+      eredex_steps_with linear_value_subst "exch_cmp" ] |
+    solve_sort ];
+  [> env_eq .. | solve_wf_subst ].
+
+Ltac unapply l r :=
+  eapply eq_term_sym;
+  eredex_steps_with l r.
+
+Ltac trans t :=
+  eapply eq_term_trans;
+  [> t | .. ].
+
+Ltac cmp_apply t1 t2 :=
+  break_cmp;
+  [> t1 | t2 ].
+
+Ltac hide_tmp := instantiate (1:= {{e ""}}); hide_implicits.
 
 Derive linear_cps
        in (elab_preserving_compiler linear_cps_subst
@@ -267,8 +499,537 @@ Proof.
     all: first [left; vm_compute; reflexivity
                | right; sort_cong; by_reduction; now t'].
   }
-  { apply TODO (*by_reduction; now t'.*). }
-  { apply TODO (*by_reduction; now t'.*). }
+  { by_reduction; now t'. }
+(* ===== bullet 6 (Linear-STLC-beta): reduce + verified explicit proof ===== *)
+  reduce. compute_eq_compilation.
+  (* ===== dance 1 ===== *)
+  match goal with
+  | [|- eq_term _ _ _ {{e #"blk_subst" {_} {_} (#"cmp" {_} {_} {_} (#"exch" {?G} {?H}) (#"csub" {?H} {?H'} {?G} {?G'} {?h} {?g})) (#"jmp" {?H'} {?G'} {?A} {?b} {?a})}} _ ] =>
+    reduce_to {{e #"blk_subst" (#"conc" {G} {H}) (#"conc" {H} {G}) (#"exch" {G} {H}) (#"blk_subst" (#"conc" {H} {G}) (#"conc" {H'} {G'}) (#"csub" {H} {H'} {G} {G'} {h} {g}) (#"jmp" {H'} {G'} {A} {b} {a}))}}
+  end.
+  match goal with
+  | [|- eq_term _ _ _ {{e #"blk_subst" {?Ga} {?Gb} (#"exch" {?G} {?H}) (#"blk_subst" {_} {_} (#"csub" {?H2} {?H'} {?G2} {?G'} {?h} {?g}) (#"jmp" {?H'} {?G'} {?A} {?b} {?a}))}} _ ] =>
+    eapply eq_term_trans; [ instantiate (1 := {{e #"blk_subst" {Ga} {Gb} (#"exch" {G} {H}) (#"jmp" {H} {G} {A} (#"val_subst" {H2} {H'} {h} (#"neg" {A}) {b}) (#"val_subst" {G2} {G'} {g} {A} {a}))}}) | ]
+  end.
+  1:term_cong.
+  1:(left; solve_sort). 1:term_refl. 1:term_refl. 1:term_refl.
+  1:(compute_eq_compilation; eredex_steps_with linear_cps_lang "jmp-subst").
+  reduce.
+  lazymatch goal with
+  | [|- eq_term _ _ _ {{e #"blk_subst" {?G1} {?G5} (#"cmp" {?G1} {?G4} {?G5} (#"cmp" {?G1} {?G3} {?G4} (#"cmp" {?G1} {?G2} {?G3} {?a} {?b}) {?c}) {?d}) {?j} }} _ ] =>
+    reduce_to {{e #"blk_subst" {G1} {G3} (#"cmp" {G1} {G2} {G3} {a} {b}) (#"blk_subst" {G3} {G5} (#"cmp" {G3} {G4} {G5} {c} {d}) {j}) }}
+  end.
+  (* ===== dance 2 ===== *)
+  hide_implicits. eapply eq_term_trans.
+  1:term_cong.
+  1:(left; solve_sort). 1:term_refl. 1:term_refl. 1:term_refl.
+  1:(compute_eq_compilation; match goal with | [|- eq_term _ _ _ {{e #"blk_subst" {_} {_} (#"cmp" {_} {_} {_} (#"exch" {?G} {?H}) (#"csub" {?H} {?H'} {?G} {?G'} {?h} {?g})) (#"jmp" {?H'} {?G'} {?A} {?b} {?a})}} _ ] => reduce_to {{e #"blk_subst" (#"conc" {G} {H}) (#"conc" {H} {G}) (#"exch" {G} {H}) (#"blk_subst" (#"conc" {H} {G}) (#"conc" {H'} {G'}) (#"csub" {H} {H'} {G} {G'} {h} {g}) (#"jmp" {H'} {G'} {A} {b} {a}))}} end).
+  1:(match goal with | [|- eq_term _ _ _ {{e #"blk_subst" {?Ga} {?Gb} (#"exch" {?G} {?H}) (#"blk_subst" {_} {_} (#"csub" {?H2} {?H'} {?G2} {?G'} {?h} {?g}) (#"jmp" {?H'} {?G'} {?A} {?b} {?a}))}} _ ] => eapply eq_term_trans; [ instantiate (1 := {{e #"blk_subst" {Ga} {Gb} (#"exch" {G} {H}) (#"jmp" {H} {G} {A} (#"val_subst" {H2} {H'} {h} (#"neg" {A}) {b}) (#"val_subst" {G2} {G'} {g} {A} {a}))}}) | ] end).
+  1:term_cong.
+  1:term_refl. 1:term_refl. 1:term_refl.
+  1:(compute_eq_compilation; eredex_steps_with linear_cps_lang "jmp-subst").
+  1:term_refl.
+  (* ===== push jmp ===== *)
+  reduce.
+  lazymatch goal with
+  | [|- eq_term _ _ _ {{e #"blk_subst" {?H1} {?H2} {?c} (#"jmp" {?G1} {?G2} {?A} (#"hd" {?B}) (#"val_subst" {?G2} {?G3} {?s} {?A} {?p})) }} _ ] =>
+    reduce_to {{e #"blk_subst" {H1} {H2} {c} (#"blk_subst" {H2} (#"conc" {G1} {G3}) (#"csub" {G1} {G1} {G2} {G3} (#"id" (#"only" {B})) {s}) (#"jmp" {G1} {G3} {A} (#"hd" {B}) {p})) }};
+    reduce_to {{e #"blk_subst" {H1} (#"conc" {G1} {G3}) (#"cmp" {H1} {H2} (#"conc" {G1} {G3}) {c} (#"csub" {G1} {G1} {G2} {G3} (#"id" (#"only" {B})) {s})) (#"jmp" {G1} {G3} {A} (#"hd" {B}) {p}) }}
+  end.
+  (* ===== continuation (old caseA 638+) ===== *)
+{
+  eapply eq_term_sym.
+  blk_cmp.
+  term_refl.
+}
+
+Unshelve.
+all: try solve_wf_term.
+Unshelve.
+all: try solve_wf_term.
+
+Optimize Proof.
+Optimize Heap.
+
+hide_implicits.
+
+eapply eq_term_trans.
+
+{
+term_cong; cycle 1.
+1, 2, 4: term_refl.
+2: left; solve_sort.
+
+compute_eq_compilation.
+
+normalize_perm.
+Unshelve.
+all: try solve_wf_term.
+Unshelve.
+all: try solve_wf_term.
+
+Optimize Proof.
+Optimize Heap.
+
+- term_refl.
+- lazymatch goal with
+  | [|- eq_term _ _ _ {{e #"cmp"
+      {?G1} {?G3} {?G4}
+      (#"cmp" {?G1} {?G2} {?G3} {?p} {?cs} )
+      {?e}
+    }} _ ] =>
+      let cs' := csub_normalize cs in
+      reduce_to {{e #"cmp" {G1} {G2} {G4} {p} (#"cmp" {G2} {G3} {G4} {cs'} {e}) }};
+      eapply eq_term_trans; [>
+      break_cmp;
+      [> term_refl | .. ];
+      eapply eq_term_trans;
+      [> break_cmp;
+        [> eredex_steps_with linear_value_subst "csub_assoc" |  term_refl ]
+        | exch_invert ]
+      | .. ];
+      compute_eq_compilation;
+      reduce_lhs;
+      break_cmp;
+      [> .. | term_refl ]
+  end.
+
+  lazymatch goal with
+  | [|- eq_term _ _ _ {{e #"cmp"
+      {?G1} {?G2} {?G3}
+      {?g1} {?g2}
+    }} _ ] => reduce_to {{e
+      #"cmp" {G1} {G2} {G3}
+      (#"cmp" {G1} {G2} {G2}
+        {g1} (#"id" {G2}))
+      {g2}
+    }}
+  end.
+
+  trans break_cmp.
+  2: term_refl.
+  1: {
+    trans break_cmp.
+    1: term_refl.
+    {
+    trans ltac:(unapply linear_value_subst "csub_id").
+    compute_eq_compilation.
+    trans ltac:(
+      term_cong;
+      cycle 1;
+      [> term_refl .. |
+         unapply linear_value_subst "id_left" |
+         unapply linear_value_subst "exch_inv" |
+         right; reflexivity ]
+    ).
+    trans ltac:(unapply linear_value_subst "cmp_csub").
+    compute_eq_compilation.
+    term_refl.
+
+    Unshelve.
+    all: try solve_wf_term.
+    Unshelve.
+    all: try solve_wf_term.
+    all: shelve.
+    }
+
+    eredex_steps_with linear_value_subst "cmp_assoc".
+    all: try (lazymatch goal with |- wf_subst _ _ _ => solve_wf_subst end).
+
+    Unshelve.
+    all: try solve_wf_term.
+    shelve.
+  }
+
+  Ltac eredex_general l r :=
+    eapply eq_term_conv;
+        [>
+          eapply eq_term_trans;
+          [> term_cong | .. ];
+          [> .. | eredex_steps_with l r ] |
+          .. ].
+
+  compute_eq_compilation.
+
+  lazymatch goal with
+    | [|- eq_term _ _ _ {{e
+      #"cmp" {?G1} {?G4} {?G5}
+        (#"cmp" {?G1} {?G3} {?G4}
+          (#"cmp" {?G1} {?G2} {?G3} {?c1} {?c2})
+          {?c3})
+        {?c4}
+    }} _ ] => reduce_to {{e
+      #"cmp" {G1} {G3} {G5}
+        (#"cmp" {G1} {G2} {G3} {c1} {c2})
+        (#"cmp" {G3} {G4} {G5} {c3} {c4})
+    }}
+  end.
+
+  trans break_cmp.
+
+  {
+  trans break_cmp.
+  1: term_refl.
+  1: unapply linear_value_subst "exch_triple".
+  compute_eq_compilation.
+  reduce_lhs.
+  trans break_cmp.
+  2: term_refl.
+  1: reduce_to {{e #"cmp" (#"conc" "G" (ext "H" (#"neg" "B"))) (
+             #"conc" (ext "H" (#"neg" "B")) "G") (
+             #"conc" "G" (ext "H" (#"neg" "B"))) (
+             #"exch" "G" (ext "H" (#"neg" "B"))) (
+             #"exch" (ext "H" (#"neg" "B")) "G")}};
+    eredex_steps_with linear_value_subst "exch_inv".
+
+  Unshelve.
+  all: try solve_wf_term.
+  Unshelve.
+  all: try solve_wf_term.
+
+  (* Optimize Proof. *) (* this doesn't work *)
+  Optimize Heap.
+
+  2-4: shelve.
+
+  reduce_lhs.
+
+  lazymatch goal with
+  | [|- eq_term _ _ {{s #"sub" {?X} {?Y} }} ?e _ ] =>
+    reduce_to {{e #"cmp" {X} {X} {Y} (#"id" {X}) {e} }}
+  end.
+
+  trans break_cmp.
+
+  Unshelve.
+  all: try solve_wf_term.
+  4-8: shelve.
+  2: term_refl.
+  {
+  trans ltac:(unapply linear_value_subst "csub_id").
+  compute_eq_compilation.
+  trans ltac:(term_cong; cycle 1;
+  [> term_refl .. |
+    unapply linear_value_subst "id_left" |
+    unapply linear_value_subst "exch_inv" |
+    right; reflexivity ]
+  ).
+  compute_eq_compilation.
+  trans ltac:(unapply linear_value_subst "cmp_csub").
+  compute_eq_compilation.
+  break_cmp.
+  1: term_refl.
+  unapply linear_value_subst "exch_triple".
+
+  Unshelve.
+  all: try solve_wf_term.
+  Unshelve.
+  all: try solve_wf_term.
+  all: shelve.
+  }
+
+  compute_eq_compilation.
+
+  reduce_lhs.
+  lazymatch goal with
+    | [|- eq_term _ _ _ {{e
+      #"cmp" {?G1} {?G4} {?G5}
+        (#"cmp" {?G1} {?G3} {?G4}
+          (#"cmp" {?G1} {?G2} {?G3} {?c1} {?c2})
+          {?c3})
+        {?c4}
+    }} _ ] => reduce_to {{e
+      #"cmp" {G1} {G3} {G5}
+        (#"cmp" {G1} {G2} {G3} {c1} {c2})
+        (#"cmp" {G3} {G4} {G5} {c3} {c4})
+    }}
+  end.
+
+  trans break_cmp.
+  1: term_refl.
+  {
+  eredex_general linear_value_subst "cmp_csub".
+  4-5: term_refl.
+  1-3: try env_eq.
+  all: try (lazymatch goal with |- wf_subst _ _ _ => solve_wf_subst end).
+  solve_sort.
+
+  Unshelve.
+  all: try solve_wf_term.
+  Unshelve.
+  all: try solve_wf_term.
+  all: shelve.
+  }
+
+  compute_eq_compilation.
+
+  reduce_lhs.
+  term_refl.
+
+  }
+
+  {
+  trans ltac:(
+    eredex_general linear_value_subst "exch_cmp";
+    cycle 3;
+    [> term_refl | term_refl |
+       solve_wf_subst |
+       solve_sort |
+       try env_eq .. ]
+  ).
+  compute_eq_compilation.
+  term_refl.
+
+  Unshelve.
+  all: try solve_wf_term.
+  Unshelve.
+  all: try solve_wf_term.
+  shelve.
+  }
+
+  reduce_lhs.
+
+  trans break_cmp.
+  2: term_refl.
+  {
+    trans ltac:(unapply linear_value_subst "cmp_assoc").
+    all: try (lazymatch goal with |- wf_subst _ _ _ => solve_wf_subst end).
+    compute_eq_compilation.
+    trans break_cmp.
+    1: term_refl.
+    {
+      reduce_to {{e #"cmp"
+        (#"conc" (ext "G" (#"neg" "B")) "H")
+        (#"conc" "H" (ext "G" (#"neg" "B")))
+        (#"conc" (ext "G" (#"neg" "B")) "H")
+        (#"exch" (ext "G" (#"neg" "B")) "H")
+        (#"exch" "H" (ext "G" (#"neg" "B")))}}.
+      eapply eq_term_conv.
+      1: eredex_steps_with linear_value_subst "exch_inv".
+      solve_sort.
+
+      Unshelve.
+      all: try solve_wf_term.
+      Unshelve.
+      all: try solve_wf_term.
+      all: shelve.
+    }
+    reduce_lhs.
+    unapply linear_value_subst "exch_triple".
+  }
+
+  reduce_lhs.
+
+  trans ltac:(unapply linear_value_subst "cmp_assoc").
+  all: try (lazymatch goal with |- wf_subst _ _ _ => solve_wf_subst end).
+
+  Unshelve.
+  all: try solve_wf_term.
+  2: shelve.
+
+  compute_eq_compilation.
+
+  trans break_cmp.
+  Unshelve.
+  all: try solve_wf_term.
+  4-6: shelve.
+  1: term_refl.
+  {
+  trans ltac:(
+    eredex_general linear_value_subst "cmp_csub";
+    cycle 3;
+    [> term_refl | term_refl |
+       solve_wf_subst |
+       solve_sort |
+       try env_eq .. ]
+  ).
+  Unshelve.
+  all: try solve_wf_term.
+  Unshelve.
+  all: try solve_wf_term.
+  2-3: shelve.
+  reduce_lhs.
+  term_refl.
+  }
+
+  reduce_lhs.
+  term_refl.
+
+- lazymatch goal with
+    | [|- eq_term _ _ _ {{e #"cmp"
+      {?G1} {?G3} {?G4}
+      (#"cmp" {?G1} {?G2} {?G3} {?p} {?cs} )
+      {?e}
+    }} _ ] =>
+      reduce_to {{e #"cmp" {G1} {G2} {G4} {p} (#"cmp" {G2} {G3} {G4} {cs} {e}) }}
+  end.
+
+
+  eapply eq_term_trans.
+  {
+
+  break_cmp; [> term_refl | .. ].
+
+  eapply eq_term_trans.
+  {
+  break_cmp; [> .. | term_refl ].
+  lazymatch goal with
+    | [|- eq_term _ _ _ {{e
+      #"csub" {?A} {?A'} {_} {_}
+      {?a}
+      (#"csub" {?B} {?B'} {?C} {?C'} {?b} {?c})
+    }} _ ] =>
+      instantiate (1:= {{e #"csub" (#"conc" {A} {B}) (#"conc" {A'} {B'}) {C} {C'}
+        (#"csub" {A} {A'} {B} {B'} {a} {b}) {c} }}); by_reduction
+    end.
+  }
+
+  eapply eq_term_trans.
+  {
+  eapply eq_term_conv;
+  [>
+    eapply eq_term_trans;
+    [> term_cong | .. ];
+    [> .. | eredex_steps_with linear_value_subst "cmp_csub" ] |
+    .. ].
+
+  all: try compute_eq_compilation.
+  5: term_refl.
+  4: term_refl.
+  1-3: try env_eq.
+  all: try (lazymatch goal with |- wf_subst _ _ _ => solve_wf_subst end).
+  1: solve_sort.
+
+  Unshelve.
+  all: try solve_wf_term.
+  Unshelve.
+  all: try solve_wf_term.
+  all: shelve.
+
+  Optimize Proof.
+  (* Optimize Heap. *) (* does not terminate in 10 minutes *)
+
+  }
+
+  reduce_lhs.
+  term_refl.
+
+  }
+
+  term_refl.
+
+  Unshelve.
+  all: try solve_wf_term.
+  Unshelve.
+  all: try solve_wf_term.
+
+- lazymatch goal with
+    | [|- eq_term _ _ _ {{e #"cmp"
+      {?G1} {?G3} {?G4}
+      (#"cmp" {?G1} {?G2} {?G3} {?p} {?cs} )
+      {?e}
+    }} _ ] =>
+      reduce_to {{e #"cmp" {G1} {G2} {G4} {p} (#"cmp" {G2} {G3} {G4} {cs} {e}) }}
+  end.
+
+  eapply eq_term_trans.
+  {
+  break_cmp; [> term_refl | .. ].
+  eapply eq_term_trans.
+  {
+  break_cmp; [> .. | term_refl ].
+  lazymatch goal with
+    | [|- eq_term _ _ _ {{e
+      #"csub" {?A} {?A'} {_} {_}
+      {?a}
+      (#"csub" {?B} {?B'} {?C} {?C'} {?b} {?c})
+    }} _ ] =>
+      instantiate (1:= {{e #"csub" (#"conc" {A} {B}) (#"conc" {A'} {B'}) {C} {C'}
+        (#"csub" {A} {A'} {B} {B'} {a} {b}) {c} }}); by_reduction
+    end.
+  }
+
+  Unshelve.
+  all: try solve_wf_term.
+  Unshelve.
+  all: try solve_wf_term.
+
+  2: shelve.
+
+  trans ltac:(eredex_general linear_value_subst "cmp_csub").
+  4-5: term_refl.
+  1-3: try env_eq.
+  all: try (lazymatch goal with |- wf_subst _ _ _ => solve_wf_subst end).
+  1: solve_sort.
+
+  Unshelve.
+  all: try solve_wf_term.
+
+  2: shelve.
+
+  compute_eq_compilation.
+
+  reduce_lhs.
+
+  lazymatch goal with
+    | [|- eq_term _ _ _ {{e
+      #"csub" {?G1} {?G2} {?H1} {?H2}
+      {?g} {?h}
+    }} _ ] => reduce_to {{e
+      #"csub" {G1} {G2} {H1} {H2}
+      {g} (#"cmp" {H1} {H1} {H2} (#"id" {H1}) {h})
+    }}
+  end.
+
+  trans ltac:(
+    eapply eq_term_conv;
+    [> unapply linear_value_subst "cmp_csub" |
+       solve_sort ]
+  ).
+
+  Unshelve.
+  all: try solve_wf_term.
+  2: shelve.
+
+  compute_eq_compilation.
+  term_refl.
+
+  }
+
+  reduce_lhs.
+
+  break_cmp.
+  2: term_refl.
+  Unshelve.
+  all: try solve_wf_term.
+  Unshelve.
+  all: try solve_wf_term.
+  2: shelve.
+
+  eapply eq_term_trans.
+  2: {
+    instantiate (1:= {{e
+      #"csub"
+        "G" "G"
+        (ext "H" (#"neg" "B")) (#"conc" (#"only" (#"neg" "B")) "H")
+        (#"id" "G")
+        (#"exch" "H" (#"only" (#"neg" "B")))
+    }}).
+
+    eredex_steps_with linear_value_subst "exch_triple".
+  }
+
+  by_reduction.
+
+- trans ltac:(unapply linear_value_subst "cmp_assoc").
+  reduce_lhs.
+  term_refl.
+}
+
+by_reduction.
+Unshelve.
+all: try solve_wf_term.
+
   Unshelve.
   all: repeat t'.
 Qed.

--- a/src/Pyrosome/Lang/LinearCPS.v
+++ b/src/Pyrosome/Lang/LinearCPS.v
@@ -242,40 +242,6 @@ Ltac normalize_env :=
   [> repeat normalize_env_step; term_refl | .. ].
 
 
-Ltac simplify_wf_term :=
-  try unfold Model.wf_term;
-  match goal with
-  | |- wf_term ?l ?c ?e ?t =>
-      let c' := eval vm_compute in c in
-      let e' := eval vm_compute in e in
-      let t' := eval vm_compute in t in
-          change_no_check (wf_term l c' e' t')
-  end.
-
-      (* Ltac eredex_steps_with' lang name :=
-  let mr := eval vm_compute in (named_list_lookup_err lang name) in
-      lazymatch mr with
-      | Some (term_eq_rule ?c ?e1p ?e2p ?tp) =>
-        lazymatch goal with
-        | [|- @eq_term ?V _ ?l ?c' ?t ?e1 ?e2] =>
-          let s := open_constr:(_:subst) in
-          first [unify_var_names V s c | fail 2 "could not unify var names"];
-          idtac t tp e1 e1p e2 e2p;
-          first [ replace (eq_term l c' t e1 e2)
-                    with (@eq_term V _ l c' tp[/s/] e1p[/s/] e2p[/s/])
-                  (* [| f_equal; vm_compute; reflexivity ]
-                | fail 2 "could not replace with subst"];
-          eapply (@eq_term_subst V _ l c' s s c);
-          [eapply (@eq_term_by V _ l c name tp e1p e2p);
-           try solve [cleanup_auto_elab]
-          | eapply eq_subst_refl; try solve [cleanup_auto_elab]
-          | try solve [cleanup_auto_elab] *)
-          ]
-        end
-      | None =>
-        fail 100 "rule not found in lang"
-      end. *)
-
 Ltac solve_wf_term := first [eapply wf_term_by';
   [> solve_in | solve_wf_args | first [left; reflexivity | right; solve_sort] ]
   | eapply wf_term_var; solve_in]
@@ -294,58 +260,6 @@ Ltac solve_wf_subst :=
   repeat (eapply wf_subst_cons; [> .. | solve_wf_term ]);
   eapply wf_subst_nil.
 
-Ltac conv_steps_with l r :=
-  eapply eq_term_conv;
-  [> eredex_steps_with l r | solve_sort].
-
-Ltac thru_steps_with l r :=
-  first [ conv_steps_with l r |
-    term_cong; try compute_eq_compilation;
-    first [
-      left; solve_sort |
-      thru_steps_with l r |
-      term_refl l r |
-      env_eq ] ].
-
-Ltac lhs_thru_steps_with l r :=
-  eapply eq_term_trans;
-  [> thru_steps_with l r | .. ].
-
-
-Ltac make_pf :=
-  lazymatch goal with
-    | [|- eq_term ?l ?c' ?t ?e1 ?e2] =>
-        (*TODO: 100 is a magic number; make it an input*)
-        let x := eval compute in (step_term_V l c' 100 e1 t) in
-          eapply pf_checker_sound with(p:=x);
-          [typeclasses eauto | assumption |]
-  end.
-
-Ltac reduce_exch :=
-  eapply eq_term_trans;
-  [> term_cong; try compute_eq_compilation;
-  lazymatch goal with
-  | [|- _ \/ _ ] => right; reflexivity
-  | [|- eq_term _ _ {{s #"env"}} _ _ ] => env_eq
-  | [|- eq_term _ _ {{s #"sub" {_} {_} }}
-      {{e #"cmp" {_} {_} {_}
-        (#"csub" {?G1} {?G2} {?H1} {?H2} {?g} {?h} )
-        (#"exch" {?G2} {?H2}) }} _ ] =>
-        eapply eq_term_conv;
-        [> eapply eq_term_trans;
-          [> term_cong; [> .. | term_refl ] |
-            compute_eq_compilation;
-            eredex_steps_with linear_value_subst "exch_cmp";
-            instantiate (8 := {{e #"id" #"emp" }});
-            instantiate (7 := h);
-            instantiate (6 := g);
-            instantiate (5 := {{e #"id" #"emp" }});
-            solve_wf_subst ] |
-          solve_sort ]
-  | [|- eq_term _ _ _ _ _ ] => term_refl
-  end;
-  by_reduction | reduce ].
-
 Ltac blk_cmp :=
   eapply eq_term_trans;
   [> lazymatch goal with
@@ -363,21 +277,6 @@ Ltac blk_cmp :=
     end
   | .. ].
 
-Ltac shelve_env :=
-  eapply eq_term_trans;
-  [> term_cong; try compute_eq_compilation;
-  lazymatch goal with
-  | [|- _ \/ _ ] => shelve
-  | [|- eq_term _ _ {{s #"env"}} _ _ ] => shelve
-  | [|- eq_term _ _ _ _ _ ] => term_refl
-  end
-  | .. ].
-
-Ltac apply_rule l r :=
-  eapply eq_term_trans;
-  [> shelve_env; eapply eq_term_conv;
-    [> eredex_steps_with l r | solve_sort ]
-  | ..].
  Ltac s :=
    match goal with
   | [|- fresh _ _ ]=> compute_fresh
@@ -394,8 +293,6 @@ Ltac apply_rule l r :=
   (* | [|- ?eq \/ ?seq ] => tryif (has_evar ?Goal) then shelve else (left; reflexivity) || shelve *)
   | [|- _ = _] => compute; reflexivity
  end.
-
-Ltac lefl := left; reflexivity.
 
 Ltac reduce_to e :=
   eapply eq_term_trans;
@@ -466,11 +363,33 @@ Ltac trans t :=
   eapply eq_term_trans;
   [> t | .. ].
 
-Ltac cmp_apply t1 t2 :=
-  break_cmp;
-  [> t1 | t2 ].
+(* left-assoc cmp of three subs -> split into two cmps *)
+Ltac reassoc_cmp4 :=
+  lazymatch goal with
+  | [|- eq_term _ _ _ {{e #"cmp" {?G1} {?G4} {?G5}
+        (#"cmp" {?G1} {?G3} {?G4} (#"cmp" {?G1} {?G2} {?G3} {?c1} {?c2}) {?c3})
+        {?c4} }} _ ] =>
+      reduce_to {{e #"cmp" {G1} {G3} {G5}
+        (#"cmp" {G1} {G2} {G3} {c1} {c2}) (#"cmp" {G3} {G4} {G5} {c3} {c4}) }}
+  end.
 
-Ltac hide_tmp := instantiate (1:= {{e ""}}); hide_implicits.
+(* cmp (cmp p cs) e -> cmp p (cmp cs e) *)
+Ltac reassoc_cmp3 :=
+  lazymatch goal with
+  | [|- eq_term _ _ _ {{e #"cmp" {?G1} {?G3} {?G4}
+        (#"cmp" {?G1} {?G2} {?G3} {?p} {?cs}) {?e} }} _ ] =>
+      reduce_to {{e #"cmp" {G1} {G2} {G4} {p} (#"cmp" {G2} {G3} {G4} {cs} {e}) }}
+  end.
+
+(* shared prefix of the two "csub_id dances" *)
+Ltac csub_id_dance :=
+  trans ltac:(unapply linear_value_subst "csub_id");
+  compute_eq_compilation;
+  trans ltac:(term_cong; cycle 1;
+    [> term_refl .. |
+       unapply linear_value_subst "id_left" |
+       unapply linear_value_subst "exch_inv" |
+       right; reflexivity ]).
 
 Derive linear_cps
        in (elab_preserving_compiler linear_cps_subst
@@ -612,16 +531,7 @@ Optimize Heap.
     trans break_cmp.
     1: term_refl.
     {
-    trans ltac:(unapply linear_value_subst "csub_id").
-    compute_eq_compilation.
-    trans ltac:(
-      term_cong;
-      cycle 1;
-      [> term_refl .. |
-         unapply linear_value_subst "id_left" |
-         unapply linear_value_subst "exch_inv" |
-         right; reflexivity ]
-    ).
+    csub_id_dance.
     trans ltac:(unapply linear_value_subst "cmp_csub").
     compute_eq_compilation.
     term_refl.
@@ -651,19 +561,7 @@ Optimize Heap.
 
   compute_eq_compilation.
 
-  lazymatch goal with
-    | [|- eq_term _ _ _ {{e
-      #"cmp" {?G1} {?G4} {?G5}
-        (#"cmp" {?G1} {?G3} {?G4}
-          (#"cmp" {?G1} {?G2} {?G3} {?c1} {?c2})
-          {?c3})
-        {?c4}
-    }} _ ] => reduce_to {{e
-      #"cmp" {G1} {G3} {G5}
-        (#"cmp" {G1} {G2} {G3} {c1} {c2})
-        (#"cmp" {G3} {G4} {G5} {c3} {c4})
-    }}
-  end.
+  reassoc_cmp4.
 
   trans break_cmp.
 
@@ -706,14 +604,7 @@ Optimize Heap.
   4-8: shelve.
   2: term_refl.
   {
-  trans ltac:(unapply linear_value_subst "csub_id").
-  compute_eq_compilation.
-  trans ltac:(term_cong; cycle 1;
-  [> term_refl .. |
-    unapply linear_value_subst "id_left" |
-    unapply linear_value_subst "exch_inv" |
-    right; reflexivity ]
-  ).
+  csub_id_dance.
   compute_eq_compilation.
   trans ltac:(unapply linear_value_subst "cmp_csub").
   compute_eq_compilation.
@@ -731,19 +622,7 @@ Optimize Heap.
   compute_eq_compilation.
 
   reduce_lhs.
-  lazymatch goal with
-    | [|- eq_term _ _ _ {{e
-      #"cmp" {?G1} {?G4} {?G5}
-        (#"cmp" {?G1} {?G3} {?G4}
-          (#"cmp" {?G1} {?G2} {?G3} {?c1} {?c2})
-          {?c3})
-        {?c4}
-    }} _ ] => reduce_to {{e
-      #"cmp" {G1} {G3} {G5}
-        (#"cmp" {G1} {G2} {G3} {c1} {c2})
-        (#"cmp" {G3} {G4} {G5} {c3} {c4})
-    }}
-  end.
+  reassoc_cmp4.
 
   trans break_cmp.
   1: term_refl.
@@ -855,14 +734,7 @@ Optimize Heap.
   reduce_lhs.
   term_refl.
 
-- lazymatch goal with
-    | [|- eq_term _ _ _ {{e #"cmp"
-      {?G1} {?G3} {?G4}
-      (#"cmp" {?G1} {?G2} {?G3} {?p} {?cs} )
-      {?e}
-    }} _ ] =>
-      reduce_to {{e #"cmp" {G1} {G2} {G4} {p} (#"cmp" {G2} {G3} {G4} {cs} {e}) }}
-  end.
+- reassoc_cmp3.
 
 
   eapply eq_term_trans.
@@ -923,14 +795,7 @@ Optimize Heap.
   Unshelve.
   all: try solve_wf_term.
 
-- lazymatch goal with
-    | [|- eq_term _ _ _ {{e #"cmp"
-      {?G1} {?G3} {?G4}
-      (#"cmp" {?G1} {?G2} {?G3} {?p} {?cs} )
-      {?e}
-    }} _ ] =>
-      reduce_to {{e #"cmp" {G1} {G2} {G4} {p} (#"cmp" {G2} {G3} {G4} {cs} {e}) }}
-  end.
+- reassoc_cmp3.
 
   eapply eq_term_trans.
   {


### PR DESCRIPTION
The e-graph `by_reduction` (shadowed in via Tools.EGraph.Automation) discharges its Is_Success premise with vm_cast_no_check, deferring the full-fuel egraph_reducing_equal' to the kernel at Qed. Two cases never converge there: linear_app-subst and Linear-STLC-beta (beta needs bidirectional rewriting over the substitution calculus's assoc/exchange rules, which the e-graph explodes on).

Fix: use the directed reducer (Ltac by_reduction := Matches.by_reduction) and an explicit proof for the beta case, ported from the old full proof at 181321a.
- import Tools.UnElab + Proof.TreeProofs; bring the explicit-tactic preamble (reduce_to, break_cmp, blk_cmp, exch_invert, normalize_env/solve_sort, unapply, trans, ...).
- bullets 1-5 unchanged in spirit (directed by_reduction; app-subst closes directed).
- bullet 6 (beta): reduce, then the exch/csub/jmp "dance" (split via blk_subst_cmp, rearrange via the auto-gen jmp-subst rule) twice + cmp-chain reassociation + 181321a's trailing block.

Drift fixes vs 181321a: the combined `term_cong; [> ... | reduce_by ...]` throws len_eq under current Coq (Ltac backtracking through ;[>]), so it's stepped; and eredex/unapply emit side-goals in a different order, so positional `1: solve_wf_subst` selectors are made order-independent.

linear_cps_preserving now compiles; axiom-free apart from the pre-existing egraph soundness admits (egraph_reducing_cong_sound, egraph_reducing_equal'_to_pos) inherited from the auto_elab language derivations.