### PR TITLE
Proper semi naive

### DIFF
--- a/WIP/PerfBench.v
+++ b/WIP/PerfBench.v
@@ -1,0 +1,382 @@
+(* Performance benchmark for egraph_reducing_equal' under vm_compute. *)
+#[local] Set Warnings "-native-compiler-disabled".
+From Stdlib Require Import Lists.List Strings.String BinNums PArith.BinPos.
+Import ListNotations.
+Open Scope string.
+Open Scope list.
+
+From coqutil Require Import Map.Interface.
+From Utils Require Import Utils Monad.
+Import StateMonad.
+From Utils Require Import TrieMap FullPosTrie FullPosTrieConv.
+From coqutil Require Import Datatypes.Result.
+From Utils.EGraph Require Import Defs.
+From Pyrosome.Theory Require Import Core.
+Import Core.Notations.
+From Pyrosome.Tools.EGraph Require Import Defs.
+Import PositiveInstantiation.
+
+(* depth analysis instance, mirroring Automation.v *)
+Instance bench_analysis : analysis string string (option positive) :=
+  weighted_depth_analysis (fun _ => Some xH).
+
+Definition filter_rules :=
+  (fun pat : string * Rule.rule string =>
+     match pat with
+     | (_, Rule.term_rule _ _ _) => false
+     | (_, Rule.sort_rule _ _) => false
+     | _ => true
+     end).
+
+Definition all_reversible : string * Rule.rule string -> bool := fun _ => true.
+Definition no_inj : list (string * list string) := [].
+
+(* Monoid with an associativity equation. *)
+Definition monoid : lang string :=
+  {[l
+  [s|
+      -----------------------------------------------
+      #"S" srt
+  ];
+  [:|  "a": #"S", "b" : #"S"
+       -----------------------------------------------
+       #"*" "a" "b" : #"S"
+  ];
+  [:=  "a": #"S", "b" : #"S", "c" : #"S"
+       ----------------------------------------------- ("assoc")
+       #"*" (#"*" "a" "b") "c"
+       = #"*" "a" (#"*" "b" "c")
+       : #"S"
+  ];
+  [:=  "a": #"S", "b" : #"S"
+       ----------------------------------------------- ("comm")
+       #"*" "a" "b"
+       = #"*" "b" "a"
+       : #"S"
+  ]
+  ]}.
+
+(* Build a context of n variables x0..x(n-1) of sort S. *)
+Fixpoint nat_name (i : nat) : string :=
+  match i with O => "" | S j => String.append "z" (nat_name j) end.
+Definition var_name (i : nat) : string := String.append "x" (nat_name i).
+Definition Ssort : sort string := scon "S" [].
+
+Fixpoint bench_ctx_n (n : nat) : ctx string :=
+  match n with
+  | 0 => []
+  | S i => (var_name i, Ssort) :: bench_ctx_n i
+  end.
+
+(* left-assoc: (((x0 * x1) * x2) * ... ) *)
+Fixpoint e_left_n (n : nat) : term string :=
+  match n with
+  | 0 => var (var_name 0)
+  | S i => con "*" [ var (var_name (S i)); e_left_n i ]
+  end.
+
+(* right-assoc: (x0 * (x1 * (x2 * ...))) over the same n+1 variables,
+   listed so the leaves match e_left_n. *)
+Fixpoint e_right_n' (lo n : nat) : term string :=
+  match n with
+  | 0 => var (var_name lo)
+  | S i => con "*" [ e_right_n' (S lo) i; var (var_name lo) ]
+  end.
+
+(* ====================================================================
+   POSITIVE instantiation benchmark (the realistic fast path).
+   We rename the string language/terms to positive via PosRenaming
+   exactly as egraph_equal' does internally, then drive the positive
+   engine (PositiveInstantiation.egraph_equal / compat_intersect).
+
+   FINDINGS (monoid assoc+comm, positive keys; vm_compute):
+   - Positive is ~15x faster than the string instantiation; the string
+     numbers were dominated by slow string `eqb` and are MISLEADING.
+   - Saturation reaches fixpoint by iteration 3 (s3..s6 plateau ~0.17s);
+     the cost is concentrated in the one expensive iteration.
+   - Per expensive iteration: build_tries ~0.01s, REBUILD is in the noise
+     (oneiter ~= oneiter_nr), and the join+writes (process_erule) phase
+     dominates (~0.3s). So on positive, rebuild/worklist are NOT the
+     bottleneck (on string they looked like it purely due to eqb cost).
+   - worklist_dedup is O(n^2) and removes ZERO entries in these saturating
+     workloads: depth 4/6/8 -> 270/773/1369 entries -> 0.011/0.12/0.273s.
+     2.9x size => ~11x time: a latent quadratic that will dominate at
+     scale (bigger languages / deeper terms). Its soundness contract is
+     only `worklist_dedup_preserves_all` (output is a sublist of input),
+     so it can be replaced by an O(n) idx_map-backed exact-dup pass that
+     keeps the identical e-graph result (re-union/re-analyze is idempotent).
+
+   process_erule split (n=6 expensive iteration, `jc` measurement):
+     build_tries 0.017s | JOIN/intersection 0.013s (1089 matches!) |
+     WRITES (exec_write) ~0.38s. The intersection algorithm is NOT the
+     bottleneck; the write-application phase is ~92% of the iteration.
+     exec_write runs once per match: rebuilds `map.of_list (combine
+     query_vars assignment)`, inserts each write-clause atom (preallocating
+     even when the node already exists -- see exec_write TODO), and unions.
+     Levers (all in verified code): (a) cut redundant matches -- the
+     semi-naive frontier uses TOTAL for every non-frontier clause, so a
+     match with k new clauses is found k times (classic double-count; a
+     proper delta split OLD<i / NEW=i / TOTAL>i finds each once); (b) avoid
+     exec_write's per-match map rebuild / redundant preallocation.
+     MEASURED redundancy (jc vs jcd): 1089 total matches but only 299
+     DISTINCT -> ~73% of exec_write calls are redundant (3.6x). Since
+     writes are ~92% of the iteration, deduping matches before exec_write
+     (or a proper delta decomposition) could cut iteration cost by ~70%.
+     exec_write is idempotent on a repeated match, so dedup is result-
+     preserving; the cheapest form is to collect+dedup assignments across
+     all frontiers in process_erule and exec_write each once.
+
+   DEDUP RESULT (process_erule now aggregates per-frontier keys into one
+   idx_trie and exec_writes each unique assignment once; runtime-only change,
+   src/Utils/EGraph/Defs.v).  Before -> after, monoid n=6, fpt engine:
+     - sat_eq full solve (s3..s6): ~0.130s -> ~0.030s  (~4.3x faster)
+     - expensive iter oneiter_nr:  0.244s -> 0.118s
+     - post-join worklist n=4/6/8: 270/773/1369 -> 52/108/168 (~7x fewer
+       redundant union entries; the O(n^2) worklist_dedup concern evaporates)
+     - worklist_dedup @ n=8:       0.21s  -> 0.003s
+   Correctness preserved: s_check/sat_eq/easy_check still true/Success.
+   (jc=1089 total vs jcd=299 distinct are computed by THIS file's own
+   per-frontier logic, so they are unchanged -- they measure the redundancy
+   the runtime change now collapses.)
+   ==================================================================== *)
+Import PosListMap.
+
+(* Rename (lang, e_left, e_right, sort, eqn-rules) to positive together,
+   so they share one renaming. Mirrors egraph_equal''s rename_and_run. *)
+Definition pos_bundle (n : nat)
+  : lang positive * term positive * term positive * sort positive * lang positive :=
+  let c := bench_ctx_n (S n) in
+  let m : state (PosRenaming.renaming string) _ :=
+    @! let l'  <- PosRenaming.rename_lang (ctx_to_rules c ++ monoid) in
+       let e1' <- PosRenaming.rename_term (var_to_con (e_left_n n)) in
+       let e2' <- PosRenaming.rename_term (var_to_con (e_right_n' 0 n)) in
+       let t'  <- PosRenaming.rename_sort (sort_var_to_con Ssort) in
+       let pr  <- PosRenaming.rename_lang
+                    (ctx_to_rules c ++ PositiveInstantiation.filter_eqn_rules monoid) in
+       ret (l', e1', e2', t', pr)
+  in
+  fst (m {| PosRenaming.p_to_v := map.empty;
+            PosRenaming.v_to_p := [];
+            PosRenaming.next_id := xO xH |}).
+
+(* Fixed bundle at n=6 (term depth 6), shared by the micro-benchmarks. *)
+Definition bnd6 := Eval vm_compute in pos_bundle 6.
+Definition l6   := Eval vm_compute in let '(l,_,_,_,_) := bnd6 in l.
+Definition e1_6 := Eval vm_compute in let '(_,e,_,_,_) := bnd6 in e.
+Definition e2_6 := Eval vm_compute in let '(_,_,e,_,_) := bnd6 in e.
+Definition t6   := Eval vm_compute in let '(_,_,_,t,_) := bnd6 in t.
+Definition pr6  := Eval vm_compute in let '(_,_,_,_,p) := bnd6 in p.
+(* build_rule_set now returns a [result]; unwrap (monoid always succeeds). *)
+Definition rs_dummy : rule_set positive positive trie_map trie_map :=
+  @Defs.Build_rule_set positive positive trie_map trie_map map.empty [] [].
+Definition rs_ac := Eval vm_compute in
+  match PositiveInstantiation.build_rule_set 100 pr6 l6 with
+  | Success rs => rs | Failure _ => rs_dummy end.
+
+(* saturation: schedule weight = fuel (#run1iter), Defs fuel = 1, as in the
+   string wrapper; mirrors that semantics on positive keys. *)
+Definition sat_eq (fuel : nat) : bool :=
+  let '(res, _, _) :=
+    fst (PositiveInstantiation.egraph_equal l6 [(fuel, rs_ac)] 100 1 e1_6 e2_6 t6) in
+  res.
+
+Definition s_check := Eval vm_compute in sat_eq 6.
+Print s_check.
+Time Definition s1  := Eval vm_compute in sat_eq 1.
+Time Definition s2  := Eval vm_compute in sat_eq 2.
+Time Definition s3  := Eval vm_compute in sat_eq 3.
+Time Definition s4  := Eval vm_compute in sat_eq 4.
+Time Definition s5  := Eval vm_compute in sat_eq 5.
+Time Definition s6  := Eval vm_compute in sat_eq 6.
+
+(* ---- profiling a single (expensive) iteration ---- *)
+(* pin the (option positive) depth analysis used by the positive engine,
+   so run1iter doesn't default to the generic unit_analysis instance. *)
+Definition an_pos : analysis positive positive (option positive) :=
+  weighted_depth_analysis (fun _ => Some xH).
+
+Arguments Defs.run1iter {idx}%_type_scope {Eqb_idx} idx_succ%_function_scope
+  idx_zero {symbol}%_type_scope {symbol_map}%_function_scope symbol_map_plus
+  {idx_map}%_function_scope idx_map_plus idx_trie%_function_scope {analysis_result}%_type_scope
+  {H} spaced_list_intersect%_function_scope rebuild_fuel%_nat_scope rs _.
+
+(* graph after 2 saturation iterations; the 3rd iteration is the expensive one *)
+Definition g_pre :=
+  Eval vm_compute in
+    snd (PositiveInstantiation.egraph_equal l6 [(2%nat, rs_ac)] 100 1 e1_6 e2_6 t6).
+
+(* DB size characterization: number of (symbol -> rows) and total rows *)
+Definition db_nsyms := Eval vm_compute in List.length (map.tuples g_pre.(db)).
+Print db_nsyms.
+Definition db_nrows :=
+  Eval vm_compute in
+    List.fold_left (fun acc p => Nat.add acc (List.length (map.tuples (snd p))))
+      (map.tuples g_pre.(db)) O.
+Print db_nrows.
+
+(* one full iteration (build_tries + join + writes + rebuild) *)
+Time Definition oneiter :=
+  Eval vm_compute in
+    (Defs.run1iter Pos.succ xH ptree_map_plus ptree_map_plus
+       (@FullPosTrie.full_pos_trie_map) (@fpt_spaced_intersect) (H:=an_pos) 100 rs_ac g_pre).
+
+(* same but rebuild_fuel = 0 : build_tries + join + writes, NO rebuild *)
+Time Definition oneiter_nr :=
+  Eval vm_compute in
+    (Defs.run1iter Pos.succ xH ptree_map_plus ptree_map_plus
+       (@FullPosTrie.full_pos_trie_map) (@fpt_spaced_intersect) (H:=an_pos) 0 rs_ac g_pre).
+
+(* build_tries alone *)
+Time Definition bt :=
+  Eval vm_compute in fst (Defs.build_tries _ _ _ _ _ _ _ _ _ rs_ac g_pre).
+
+(* ---- isolate join vs rebuild ---- *)
+(* state after the join phase (rebuild_fuel=0), before any rebuild *)
+Definition g_join :=
+  Eval vm_compute in
+    snd (Defs.run1iter Pos.succ xH ptree_map_plus ptree_map_plus
+           (@FullPosTrie.full_pos_trie_map) (@fpt_spaced_intersect) (H:=an_pos) 0 rs_ac g_pre).
+Definition wl_len := Eval vm_compute in List.length g_join.(worklist).
+Print wl_len.
+Definition rows_after_join :=
+  Eval vm_compute in
+    List.fold_left (fun acc p => Nat.add acc (List.length (map.tuples (snd p))))
+      (map.tuples g_join.(db)) O.
+Print rows_after_join.
+(* rebuild alone, applied to the post-join state *)
+Time Definition rb :=
+  Eval vm_compute in snd (Defs.rebuild (H:=an_pos) 100 g_join).
+
+(* cost of one worklist_dedup pass over the worklist *)
+Time Definition wd :=
+  Eval vm_compute in List.length (@Defs.worklist_dedup _ _ g_join.(worklist)).
+Print wd.
+
+(* ---- split process_erule: JOIN (intersection) vs WRITES ---- *)
+(* db_tries for g_pre is precomputed, so `jc` times only the intersection
+   work across all rules/frontiers (no exec_write). Then
+   writes ~= oneiter_nr - build_tries - jc. *)
+Definition db_tries6 :=
+  Eval vm_compute in fst (Defs.build_tries _ _ _ _ _ _ _ _ _ rs_ac g_pre).
+
+Definition join_count : nat :=
+  List.fold_left
+    (fun (acc : nat) (r : Defs.erule positive positive) =>
+       let qptrs := @Defs.query_clause_ptrs positive positive r in
+       let qv := @Defs.query_vars positive positive r in
+       let nclauses := List.length (uncurry cons qptrs) in
+       List.fold_left
+         (fun acc2 fn =>
+            let fr := @Defs.idx_of_nat positive Pos.succ xH fn in
+            let tries :=
+              ne_map (@Defs.trie_of_clause positive _ positive trie_map trie_map
+                        (@FullPosTrie.full_pos_trie_map) qv db_tries6 fr) qptrs in
+            Nat.add acc2
+              (List.length (@Defs.intersection_keys positive (@FullPosTrie.full_pos_trie_map)
+                              (@fpt_spaced_intersect) tries)))
+         (seq 0 nclauses) acc)
+    (@Defs.compiled_rules positive positive trie_map trie_map rs_ac) O.
+
+Time Definition jc := Eval vm_compute in join_count.
+Print jc.
+
+(* DISTINCT matches per rule (dedup assignments across all frontier choices).
+   jc (total) >> jcd (distinct) would confirm semi-naive double-counting:
+   the same match re-found (and re-written) once per new clause it contains. *)
+Fixpoint dedup_assigns (l : list (list positive)) : list (list positive) :=
+  match l with
+  | [] => []
+  | x :: xs =>
+      let r := dedup_assigns xs in
+      if List.existsb (eqb x) r then r else x :: r
+  end.
+
+Definition join_distinct : nat :=
+  List.fold_left
+    (fun (acc : nat) (r : Defs.erule positive positive) =>
+       let qptrs := @Defs.query_clause_ptrs positive positive r in
+       let qv := @Defs.query_vars positive positive r in
+       let nclauses := List.length (uncurry cons qptrs) in
+       let all_assigns :=
+         List.flat_map
+           (fun fn =>
+              let fr := @Defs.idx_of_nat positive Pos.succ xH fn in
+              let tries :=
+                ne_map (@Defs.trie_of_clause positive _ positive trie_map trie_map
+                          (@FullPosTrie.full_pos_trie_map) qv db_tries6 fr) qptrs in
+              @Defs.intersection_keys positive (@FullPosTrie.full_pos_trie_map) (@fpt_spaced_intersect) tries)
+           (seq 0 nclauses) in
+       Nat.add acc (List.length (dedup_assigns all_assigns)))
+    (@Defs.compiled_rules positive positive trie_map trie_map rs_ac) O.
+
+Definition jcd := Eval vm_compute in join_distinct.
+Print jcd.
+
+(* ---- worklist_dedup scaling: confirm O(n^2) on positive keys ---- *)
+(* post-join worklist for a given term depth n (the expensive 3rd iteration). *)
+Definition gjoin_wl (n : nat) : list (Defs.worklist_entry positive) :=
+  let '(l, e1, e2, t, pr) := pos_bundle n in
+  let rs := match PositiveInstantiation.build_rule_set 100 pr l with
+            | Success rs => rs | Failure _ => rs_dummy end in
+  let gp := snd (PositiveInstantiation.egraph_equal l [(2%nat, rs)] 100 1 e1 e2 t) in
+  (snd (Defs.run1iter Pos.succ xH ptree_map_plus ptree_map_plus
+          (@FullPosTrie.full_pos_trie_map) (@fpt_spaced_intersect) (H:=an_pos) 0 rs gp)).(worklist).
+
+Definition wl4 := Eval vm_compute in gjoin_wl 4.
+Definition wl6 := Eval vm_compute in gjoin_wl 6.
+Definition wl8 := Eval vm_compute in gjoin_wl 8.
+Definition n4 := Eval vm_compute in List.length wl4. Print n4.
+Definition n6 := Eval vm_compute in List.length wl6. Print n6.
+Definition n8 := Eval vm_compute in List.length wl8. Print n8.
+Time Definition wd4 := Eval vm_compute in List.length (@Defs.worklist_dedup _ _ wl4).
+Time Definition wd6 := Eval vm_compute in List.length (@Defs.worklist_dedup _ _ wl6).
+Time Definition wd8 := Eval vm_compute in List.length (@Defs.worklist_dedup _ _ wl8).
+
+(* ---- build_rule_set scaling (per-call SETUP cost) ---- *)
+Import Rule.
+Definition opname (i : nat) : string := String.append "*" (nat_name i).
+(* NB: lists are parenthesized as (con op ([...])) to avoid clashing with an
+   `id [ _ ]` indexing notation brought in by the map imports. *)
+Definition op_term_rule (i : nat) : string * rule string :=
+  (opname i, term_rule [("b",Ssort);("a",Ssort)] ["a";"b"] Ssort).
+Definition op_assoc_rule (i : nat) : string * rule string :=
+  let op := opname i in
+  (String.append "assoc" (nat_name i),
+   term_eq_rule [("c",Ssort);("b",Ssort);("a",Ssort)]
+     (con op ([con op ([var "a"; var "b"]); var "c"]))
+     (con op ([var "a"; con op ([var "b"; var "c"])])) Ssort).
+Definition op_comm_rule (i : nat) : string * rule string :=
+  let op := opname i in
+  (String.append "comm" (nat_name i),
+   term_eq_rule [("b",Ssort);("a",Ssort)]
+     (con op ([var "a"; var "b"])) (con op ([var "b"; var "a"])) Ssort).
+
+Definition big_lang (n : nat) : lang string :=
+  List.flat_map (fun i => [op_comm_rule i; op_assoc_rule i; op_term_rule i])
+    (List.rev (seq 0 n))
+  ++ [("S", sort_rule [] [])].
+
+(* An EASY goal (a = a) on a realistic-sized language: should be setup-bound. *)
+Definition easy (n : nat) : Result.result unit :=
+  fst (egraph_reducing_equal' (big_lang n) filter_rules all_reversible no_inj
+         100 100 100 100 [("a", Ssort)] (var "a") (var "a")).
+Definition easy_check := Eval vm_compute in easy 20.
+Print easy_check.
+Time Definition e20 := Eval vm_compute in easy 20.
+Time Definition e40 := Eval vm_compute in easy 40.
+
+(* decompose setup: rename vs (positive) build_rule_set *)
+From Pyrosome.Tools Require Import PosRenaming.
+Definition l_str (n : nat) : lang string :=
+  Defs.ctx_to_rules [("a", Ssort)] ++ big_lang n.
+Definition rstate0 : PosRenaming.renaming string :=
+  {| PosRenaming.p_to_v := map.empty;
+     PosRenaming.v_to_p := [];
+     PosRenaming.next_id := xO xH |}.
+Definition lp40 := Eval vm_compute in fst (PosRenaming.rename_lang (l_str 40) rstate0).
+Time Definition t_rename40 :=
+  Eval vm_compute in fst (PosRenaming.rename_lang (l_str 40) rstate0).
+Time Definition t_pbuild40 :=
+  Eval vm_compute in
+    PositiveInstantiation.build_rule_set 100
+      (PositiveInstantiation.filter_eqn_rules lp40) lp40.

--- a/WIP/proper_semi_naive_design.md
+++ b/WIP/proper_semi_naive_design.md
@@ -1,0 +1,226 @@
+# Proper semi-naive evaluation for `process_erule` — design / prep doc
+
+Branch: `proper-semi-naive` (off `egraph-dedup-writes`, which carries Phase 1
+runtime dedup + Phase 2 soundness, commit `cab9088`). This is the **deeper
+change** that replaces the post-hoc dedup hack with a principled delta
+decomposition so each new match is generated exactly once.
+
+Status: **NOT STARTED — this is a prep doc for the next session.** Everything
+below is design; no code/proof has been written on this branch yet.
+
+---
+
+## 0. Background: where we are
+
+Phase 1 (`80c8afd`) found that on the positive engine the **writes**
+(`exec_write`), not the join, dominate a saturation iteration (~92%), and that
+the semi-naive frontier loop double-counts matches (n=6 monoid: 1089 total
+matches, only 299 distinct → ~73% redundant). Phase 1 dedups assignments across
+frontiers before `exec_write` (idempotent on repeats), cutting sat_eq ~0.130s →
+~0.030s. Phase 2 (`cab9088`) updated the soundness proofs; `egraph_sound` stays
+axiom-free.
+
+Phase 1 is a **collapse-after-the-fact** fix: it still runs the join for every
+frontier choice and then throws away duplicate keys. Proper semi-naive instead
+**never generates the duplicates**, by giving each clause one of three roles per
+frontier position.
+
+---
+
+## 1. The mechanism today (full / frontier dichotomy)
+
+Per-clause trie data (`Defs.v`):
+
+- `db := symbol_map (idx_trie db_entry)`; `db_entry := { entry_epoch; entry_value; out_args }`.
+  Each `(symbol f, args)` has **one** entry with **one** `entry_epoch`.
+- `build_tries_for_symbol current_epoch q_clauses tbl : idx_map (idx_trie unit * idx_trie unit)`
+  produces, per clause id `n`, a pair `(full, frontier)`:
+  - `full`  = every assignment matching the clause (key = projected assignment, val = tt).
+  - `frontier` = assignments matched via an entry with `entry_epoch == current_epoch`
+    (the **NEW**/delta set). Built by `if eqb epoch current_epoch then put frontier ... else frontier`.
+  So `frontier ⊆ full`, and (since each args has one entry/epoch) `full` partitions
+  into `frontier` (epoch = current) and "the rest" (epoch ≠ current = **OLD**).
+- `trie_of_clause query_vars db_tries frontier_n (Build_erule_query_ptr f n clause_vars)`
+  selects, for this clause, `frontier` **iff** `eqb n frontier_n`, else `full`.
+- `process_erule` (post-Phase-1) iterates `frontier_n` over `seq 0 nclauses`
+  (mapped through `idx_of_nat`), unions all frontiers' intersection keys into one
+  deduping `idx_trie`, and `exec_write`s each unique key once.
+
+Double-count cause: a match where clauses `j1, j2` are both NEW is produced at
+`frontier_n = j1` (frontier∩full∩…) **and** at `frontier_n = j2`.
+
+### ⚠ Critical wrinkle: `n` is NOT a position
+
+`compile_query_clause` (`QueryOpt.v:998`) sets the ptr's id via
+`hash_clause compiled_clause`, i.e. a **per-symbol hash-cons id**
+(`map_inverse_get`, ids 0,1,2… *per symbol* `f`). So:
+
+- The clause id `n` is **not** the clause's index in `query_clause_ptrs`.
+- `eqb n frontier_n` can select the frontier trie for the *wrong* clause, for
+  *several* clauses (same per-symbol id across symbols), or for *none*.
+- This is **sound regardless** (frontier ⊆ full ⇒ any selection still yields real
+  matches), which is exactly why the current scheme gets away with it. There is a
+  `TODO: frontier_n a hack` at `Defs.v:815`.
+
+Proper semi-naive needs a genuine **total order on the query clauses** and each
+clause's **position** in it. The ne-list order of `query_clause_ptrs` is the
+obvious choice. **This is the central restructuring**, not the OLD trie.
+
+---
+
+## 2. Target: OLD / NEW / TOTAL trichotomy, min-index assignment
+
+Query `Q = C_0 ∧ … ∧ C_{k-1}` (positions = ne-list order). Per clause define
+three key-sets:
+
+- `NEW_j`   = assignments matching `C_j` via an entry with `epoch == current`.
+- `OLD_j`   = assignments matching `C_j` via an entry with `epoch ≠ current` (= `< current`).
+- `TOTAL_j` = `OLD_j ∪ NEW_j` (= today's `full`).
+
+Frontier `i` (for `i = 0..k-1`) intersects:
+
+```
+OLD_0 ∧ … ∧ OLD_{i-1} ∧ NEW_i ∧ TOTAL_{i+1} ∧ … ∧ TOTAL_{k-1}
+```
+
+**Exactly-once:** for any match, let `S = { j : C_j matched by a NEW entry }`.
+A "new match" has `S ≠ ∅`. The decomposition counts it at `i = min S` and only
+there: `C_i` is NEW ✓; for `j < i`, `j ∉ S` so `C_j` is OLD ✓; for `j > i`,
+TOTAL covers either ✓. Every other `i'` fails (`i' < min S` ⇒ some `j ≤ i'` in
+the OLD-prefix is actually NEW; `i' > min S` and `i' ∈ S` ⇒ fine but `min S`'s
+OLD-prefix already excludes it — only `min S` has the full OLD prefix matching).
+⇒ **no dedup trie needed**; `process_erule` reverts to one `exec_write` pass per
+frontier (like the pre-dedup shape) but with non-overlapping key sets.
+
+Note epochs only increase and entries are stamped at creation, so every entry
+has `epoch ≤ current`; thus `OLD = (epoch ≠ current) = (epoch < current)` — no
+`<` on `idx` is required, plain disequality suffices.
+
+---
+
+## 3. Runtime changes (`src/Utils/EGraph/Defs.v`)
+
+1. **`build_tries_for_symbol`**: also accumulate `OLD`. Cleanest is a **triple**
+   `(full, new, old)` (rename `frontier`→`new`). `upd_trie_pair`:
+   ```
+   full'        := put full assignment tt;
+   if eqb epoch current_epoch then (full', put new assignment tt, old)
+                              else (full', new,                    put old assignment tt)
+   ```
+   Result type `idx_map (idx_trie unit * idx_trie unit * idx_trie unit)`.
+   (Alternative: keep `(full, new)` and compute `old` as a trie key-difference in
+   `trie_of_clause`; rejected — O(n) per lookup and an extra map op to verify.)
+
+2. **Position-indexed iteration.** Replace the id-based `frontier_n` with a
+   POSITION. Options:
+   - (a) Pre-zip: build `indexed_ptrs : ne_list (nat * erule_query_ptr)` once
+     (`ne_combine (seq 0 k) query_clause_ptrs`), and have the new
+     `trie_of_clause_sn frontier_pos (pos, ptr)` compare `pos ?= frontier_pos`
+     (`<` / `=` / `>`) to pick `old`/`new`/`full`. This keeps the per-clause
+     selection a pure function of position, which the soundness proof wants.
+   - (b) Thread an index through `ne_map` (need an indexed `ne_map`).
+   Prefer (a). Add `ne_combine` / indexed map helpers to `Utils` if absent.
+
+3. **New `trie_of_clause_sn`** (semi-naive): like `trie_of_clause` but takes the
+   clause's position and selects `old` (pos < fn) / `new` (pos = fn) / `full`
+   (pos > fn). Keep the old `trie_of_clause` (used by `process_erule'` and its
+   still-compiling proof) and `trie_of_clause'` (diagnostic `run_query`) intact.
+
+4. **`process_erule`**: drop the dedup trie; for each frontier position
+   `i ∈ seq 0 k`, intersect the position-indexed tries and `exec_write` each key.
+   I.e. essentially the **pre-dedup** `list_Miter (process_erule'_sn …) (seq 0 k)`
+   with `process_erule'_sn` using `trie_of_clause_sn`. `erule_frontier_keys` can
+   be retired or kept for benches.
+
+Keep changes **additive** where cheap so the existing (now-passing) lemmas about
+`trie_of_clause` / `process_erule'` don't need editing.
+
+---
+
+## 4. Proof changes — *soundness only*, and it's small
+
+**KEY INSIGHT: `egraph_sound` needs soundness (no spurious writes), NOT
+completeness/exactly-once.** Exactly-once is a *performance* property. So the
+trichotomy needs only: *every key produced still corresponds to a real match*.
+
+The whole soundness pipeline already reduces a trie hit to a db atom via
+`build_tries_sound`, with `frontier`/`full` both routed through it
+(`clause_ptr_atom_in_db`, `Semantics.v:915`):
+
+- `full` hit → `build_tries_sound` (direct).
+- `frontier` hit → `build_tries_frontier_subset` (frontier ⊆ full) → `build_tries_sound`.
+
+`OLD ⊆ full` identically, so:
+
+1. Add `build_tries_for_symbol_old_subset` + `build_tries_old_subset`
+   (copy `*_frontier_subset`, `Semantics.v:807`/`888`, swap the `new` branch for
+   the `old` branch). With the `(full,new,old)` triple, `old ⊆ full` is the same
+   fold invariant.
+2. Generalize `clause_ptr_atom_in_db` to the 3-way selection: a hit in
+   `old`/`new`/`full` all reduce to `build_tries_sound` on `full` via the subset
+   lemmas. (If `build_tries`'s result type changes to the triple, update the few
+   destructs `[ [full new old] | ]`.)
+3. **`process_erule_sound`**: the soundness core
+   **`exec_write_loop_sound` (already on this branch, `SemanticsProcessErule.v`)
+   is exactly the right tool** — it's frontier-parametric and consumes, per key,
+   an existential "this key's per-clause projections hit *some* selection of
+   tries that are each sound". Re-wire its per-frontier premise to the new
+   `trie_of_clause_sn` selection. Because each clause trie (old/new/full) hit ⇒
+   real db atom (step 2), `query_atoms_sound` goes through unchanged (its
+   conclusion is selection-independent). Expect `process_erule_sound`'s proof to
+   look like the pre-dedup per-frontier induction calling `exec_write_loop_sound`
+   (or `process_erule'_sound`-shaped), NOT the dedup membership argument.
+4. `fold_put_keys_inner/src` become **dead** (no dedup trie) — delete with the
+   `Maps` import if nothing else needs it.
+
+What does **not** need touching: `exec_write_sound`, `query_atoms_sound`,
+`a_q_wf_query_vars`, `query_clause_ptr_sound`, the saturate chain signature
+(`process_erule_sound` keeps its statement), `egraph_sound` wiring.
+
+**Risk note:** if the runtime switches `query_clause_ptrs` iteration to a
+position-indexed structure, the *coverage* hypotheses fed into
+`process_erule_sound` from `build_rule_set` (the `Hwf`/`Hcov`/`Hsli` family in
+`SemanticsSaturate`/`QueryOptSound`) must still be derivable for the new
+per-position tries. Check `QueryOptSound.v` discharges of the `Hlen_sig`/`Hsli`
+premises — they currently quantify over an arbitrary `frontier_n : idx`; the new
+ones quantify over a position `i : nat`. This is the most likely place real
+proof work hides. Scope it first.
+
+---
+
+## 5. Suggested next-session order
+
+1. **Resolve the position question** (Section 3.2): add `ne_combine`/indexed map
+   helper; settle `trie_of_clause_sn`'s signature. Smallest commit, unblocks all.
+2. Runtime: `(full,new,old)` triple in `build_tries_for_symbol` + `build_tries`;
+   `trie_of_clause_sn`; rewrite `process_erule`. Build `Defs.vo` only.
+3. **Benchmark first** (WIP/PerfBench.v, positive, monoid n=6): confirm
+   correctness (`s_check`/`sat_eq`/`easy_check`) and measure. NB Phase 1 already
+   captured the *write* win; proper semi-naive's marginal runtime gain is mainly
+   a smaller join (OLD-prefixes) + no dedup-trie build — **could be modest**.
+   Decide if it's worth the proof cost before doing the proofs. (Honest framing
+   for the user; see [[project_egraph_perf]].)
+4. Proofs: `*_old_subset`, generalize `clause_ptr_atom_in_db`, re-wire
+   `process_erule_sound` via `exec_write_loop_sound`; chase `QueryOptSound`
+   `Hsli`/`Hlen_sig` discharges. Build the chain to `Automation.vo`.
+5. `Print Assumptions egraph_sound` = "Closed under the global context"
+   (scratch coqc with the four `-R` flags; the MCP coqc doesn't read `_CoqProject`,
+   and MCP `rocq_start`/`rocq_assumptions` choke on this file's sections — use
+   `make -f Makefile.coq <ABSOLUTE path>.vo`).
+
+---
+
+## 6. File/line index (as of `cab9088`)
+
+- `Defs.v:50` `db_entry`; `:511` `build_tries_for_symbol`; `:533` `build_tries`;
+  `:558` `trie_of_clause` (semi-naive); `:574` `process_erule'`; `:585`
+  `erule_frontier_keys`; `:606` `process_erule`; `:792` `trie_of_clause'`
+  (diagnostic); `:811` `run_query`.
+- `QueryOpt.v:998` `compile_query_clause` (the `hash_clause`/`n` source).
+- `Semantics.v:659` `build_tries_for_symbol_sound`; `:766` `build_tries_sound`;
+  `:807` `*_frontier_subset`; `:888` `build_tries_frontier_subset`; `:915`
+  `clause_ptr_atom_in_db`.
+- `SemanticsProcessErule.v`: `exec_write_loop_sound` (soundness core, reusable),
+  `fold_put_keys_inner/src` (dedup-only, will be dead), `process_erule_sound`.
+- `SemanticsSaturate.v:157` consumes `process_erule`; `:167` `process_erule_sound`.
+- Related memory: [[project_egraph_perf]], [[project_egraph_sound]].

--- a/WIP/proper_semi_naive_design.md
+++ b/WIP/proper_semi_naive_design.md
@@ -188,6 +188,100 @@ proof work hides. Scope it first.
 
 ---
 
+## 4b. STATUS UPDATE — runtime done + benchmarked (2026-06-05)
+
+**Runtime DONE** (src/Utils/EGraph/Defs.v, `Defs.vo` builds):
+- added `ne_map_idx` (position-indexed ne_list map);
+- `build_tries_for_symbol`/`build_tries` now produce the `(full,new,old)` triple
+  (`idx_map (idx_trie unit * idx_trie unit * idx_trie unit)`);
+- new `trie_of_clause_sn` selects old/new/full by `Nat.compare pos frontier_pos`;
+- new `process_erule'_sn` + rewritten `process_erule` = one `exec_write` pass per
+  frontier *position* over `seq 0 nclauses`, NO dedup trie;
+- `trie_of_clause`/`trie_of_clause'` kept (updated to destruct the triple).
+
+**To benchmark, the proof stack had to compile** (the positive engine
+`PositiveInstantiation` lives downstream of `Semantics`+`QueryOpt`, so `Defs.vo`
+alone is NOT runnable — the design's step-2 "build Defs.vo only" was a gap).
+`Semantics.v`'s ENTIRE breakage = the 5 build_tries lemmas (659–980); migrated
+their statements to the triple and **`Admitted` the bodies** (benchmark only —
+these are the real proofs to write in step 4). `QueryOpt.vo`/`Tools.EGraph.Defs.vo`
+then compile unchanged.
+
+**BENCHMARK (WIP/PerfBench.v, positive, monoid assoc+comm n=6; vm_compute):**
+Correctness preserved: `s_check = true`, `easy_check = Success tt`.
+
+| metric | raw (pre-Ph1) | Phase-1 dedup | **proper SN** |
+|---|---|---|---|
+| full solve s3..s6 | ~0.130s | ~0.030s | **~0.018s** |
+| expensive iter (oneiter_nr) | 0.244s | 0.118s | **0.091s** |
+| post-join worklist n=4/6/8 | 270/773/1369 | 52/108/168 | **34/74/116** |
+| build_tries (bt) | — | — | 0.008s |
+
+⇒ proper SN is ~1.6× faster than Phase-1 on the full solve and produces ~1.4×
+fewer redundant union entries (non-overlapping key sets). Real but **modest**
+marginal win over the already-committed Phase-1 (Phase 1 captured the big write
+win; SN adds smaller-join + exactly-once). jc=1089/jcd=299 unchanged (diagnostic,
+measured via the OLD `trie_of_clause`).
+
+## 4c. STATUS (2026-06-05, end of session) — Phase A DONE, downstream DEFERRED
+
+Decision (user): **commit the proven runtime + Phase A + benchmark; defer the
+join-layer migration to a later session.** Reason: the marginal ~1.6× win does
+not currently justify re-deriving the trie #4 join-correctness layer.
+
+**DONE & committed (this branch):**
+- Runtime: `src/Utils/EGraph/Defs.v` — triple tries, `ne_map_idx`,
+  `trie_of_clause_sn`, sn `process_erule`. `Defs.vo` builds.
+- Phase A: `src/Utils/EGraph/Semantics.v` — **8 lemmas now REAL `Qed`, 0 Admitted**:
+  the 5 migrated build_tries lemmas + `build_tries_for_symbol_old_subset`
+  + `build_tries_old_subset` + `clause_ptr_atom_in_db_sn` (3-way). `Semantics.vo`
+  builds clean.
+- `QueryOpt.vo` + `Pyrosome/Tools/EGraph/Defs.vo` rebuilt against the new
+  Defs+Semantics (their `Semantics` import is load-bearing via `sequent`).
+- Benchmark validated (PerfBench, §4b).
+
+**DEFERRED — downstream proof chain does NOT yet build against the new Defs.**
+The (full,new,old) triple type + sn `process_erule` break these files; each needs
+migration (mechanical — the hard generic join math `pt_spaced_intersect_correct`
+is already done and reused). Build order (bottom-up):
+
+1. `SemanticsProcessErule.v` — rewire. Add `query_clause_ptr_sound_sn`,
+   `query_atoms_sound_sn` (key by POSITION via `nth_error (uncurry cons
+   query_clause_ptrs) pos`, using `clause_ptr_atom_in_db_sn`), `process_erule'_sn_sound`
+   (mirror `process_erule'_sound` with `ne_map_idx (trie_of_clause_sn ... frontier_pos)`),
+   and rewrite `process_erule_sound` to induct over `seq 0 nclauses` calling
+   `process_erule'_sn_sound`. The old `trie_of_clause` chain (query_atoms_sound,
+   process_erule'_sound, exec_write_loop_sound) can stay (becomes dead, still
+   compiles). NEW `process_erule_sound` Hlen/Hsli premises (these set the
+   interface for everything downstream):
+   - `Hlen_sn`: `∀ frontier_pos sigma, In sigma (intersection_keys (ne_map_idx (fun pos ptr => trie_of_clause_sn ... (query_vars r) db_tries frontier_pos pos ptr) (query_clause_ptrs r))) → length (query_vars r) = length sigma`.
+   - `Hsli_sn`: same `In sigma …` antecedent, then `∀ pos fsym nptr cvars, nth_error (uncurry cons (query_clause_ptrs r)) pos = Some (Build_erule_query_ptr … fsym nptr cvars) → map.get (fst (trie_of_clause_sn … frontier_pos pos (Build_… fsym nptr cvars))) (proj sigma cvars) = Some tt`.
+2. `SemanticsSaturate.v` — `run1iter_rule_hyps` conjuncts 9,10 (currently lines
+   101–120, `trie_of_clause`/`frontier_n`) → the sn `Hlen_sn`/`Hsli_sn` shape above.
+   `run1iter_sound`'s destructure/call (lines 166–167) pass them positionally — should
+   still go through once the shapes match the new `process_erule_sound`.
+3. `BuildTriesDepth.v` — `bt_inv`/`build_tries_for_symbol_depth` (lines ~159–179)
+   destruct `ft as [full frontier]`; migrate to the triple `[[full new] old]` and
+   prove all THREE components have `fpt_depth … (clen cl)` (old is symmetric to
+   full/new — every `put` uses a `clen`-length key).
+4. `QueryOptSound.v` — `compiled_rules_run1iter_rule_hyps` (line 5110): its `H9`/`H10`
+   params (lines 5122–5153) → sn shape; they are still just threaded through
+   (`exact H9./exact H10.`), so only the param TYPES change to match conjuncts 9,10.
+5. `QcAlignment.v` (hardest, but mechanical) — migrate `trie_of_clause_depth`
+   (line 62; triple destruct + the `Nat.compare`-3-way for an sn variant
+   `trie_of_clause_sn_depth`), `intersection_inputs_combined_bools` (bools are
+   selection-INDEPENDENT = `variable_flags`, so identical), `trie_inputs_fpt_depth`
+   (now over old/new/full, all `clen`), `trie_intersect_depth`, and finally
+   `trie_join_H9`/`trie_join_H10` (lines 710/823) → sn variants
+   `trie_join_H9_sn`/`trie_join_H10_sn` over `ne_map_idx (trie_of_clause_sn …
+   frontier_pos)`, matching the `Hlen_sn`/`Hsli_sn` shape. Same generic
+   `compat_intersect`/`pt_spaced_intersect_correct` core.
+6. `Pyrosome/Tools/EGraph/Automation.v` — the two call sites (lines 430–431,
+   466–467) pass `QcAlignment.trie_join_H9/H10`; point them at the `_sn` variants.
+
+Then: full build to `Automation.vo`, `Print Assumptions egraph_sound` = "Closed
+under the global context", re-run PerfBench. See [[project_egraph_sound]].
+
 ## 5. Suggested next-session order
 
 1. **Resolve the position question** (Section 3.2): add `ne_combine`/indexed map

--- a/src/Pyrosome/Tools/EGraph/AdapterGlue.v
+++ b/src/Pyrosome/Tools/EGraph/AdapterGlue.v
@@ -46,6 +46,7 @@ Section WithVar.
   Notation atom := (atom V V).
 
   Context (succ : V -> V).
+  Context (V_leb : V -> V -> bool).
   Context (sort_of : V).
   Context (lt : V -> V -> Prop).
   Context (lt_asymmetric : Asymmetric lt)
@@ -65,7 +66,7 @@ Section WithVar.
   Proof.
     intros al Hin.
     assert (Hin' : In al (db_to_atoms (db e))).
-    { apply (proj2 (in_db_to_atoms_iff_atom_in_db V V_Eqb V_Eqb_ok lt succ V_default
+    { apply (proj2 (in_db_to_atoms_iff_atom_in_db V V_Eqb V_Eqb_ok lt succ V_default V_leb
                       V V_Eqb V_Eqb_ok V_map V_map_ok V_trie V_trie_ok al (db e))).
       exact Hin. }
     pose proof (in_map atom_clause _ _ Hin') as Hin_map.
@@ -487,11 +488,11 @@ Section WithVar.
     Proof.
       intros al Hin.
       assert (Hin' : In al (db_to_atoms (db e))).
-      { apply (proj2 (in_db_to_atoms_iff_atom_in_db V V_Eqb V_Eqb_ok lt succ V_default
+      { apply (proj2 (in_db_to_atoms_iff_atom_in_db V V_Eqb V_Eqb_ok lt succ V_default V_leb
                         V V_Eqb V_Eqb_ok V_map V_map_ok V_trie V_trie_ok al (db e))).
         exact Hin. }
       exact (in_all _ _ _
-        (@QueryOptSound.db_to_atoms_sound V V_Eqb V_Eqb_ok lt succ V_default
+        (@QueryOptSound.db_to_atoms_sound V V_Eqb V_Eqb_ok lt succ V_default V_leb
            V V_Eqb V_Eqb_ok V_map V_map_ok V_map V_trie V_trie_ok (lang_model l) i e Hsnd)
         (in_map (@atom_clause V V) _ _ Hin')).
     Qed.
@@ -519,7 +520,7 @@ Section WithVar.
       split; [exact Hsnd_concl|].
       split; [exact Hai2|].
       intros al Hin_al.
-      exact (QueryOptSound.atom_sound_extend V lt succ V_default V V_map (lang_model l)
+      exact (QueryOptSound.atom_sound_extend V lt succ V_default V_leb V V_map (lang_model l)
                i1 i2 al Hext12 (egraph_atoms_sound i1 _ Hsnd_i1 al Hin_al)).
     Qed.
 
@@ -572,7 +573,7 @@ Section WithVar.
            V_map V_map_ok V_map V_trie V_trie_ok) as Hira.
         pose proof (Hira X (db_to_atoms (db e_assum)) e_concl a0 Ha0) as Hin_concl.
         exact (in_all _ _ _
-          (@QueryOptSound.db_to_atoms_sound V V_Eqb V_Eqb_ok lt succ V_default V V_Eqb V_Eqb_ok
+          (@QueryOptSound.db_to_atoms_sound V V_Eqb V_Eqb_ok lt succ V_default V_leb V V_Eqb V_Eqb_ok
              V_map V_map_ok V_map V_trie V_trie_ok (lang_model l) i2 e_concl Hsnd)
           (in_map (@atom_clause V V) _ _ Hin_concl)).
     Qed.
@@ -1140,7 +1141,7 @@ Section WithVar.
       cbn [clause_vars] in Hk_in.
       (* HA_in : In A (db_to_atoms (db e_assum)); convert to atom_in_egraph *)
       assert (HA : @Semantics.atom_in_egraph V V V_map V_map V_trie X A e_assum).
-      { apply (proj1 (in_db_to_atoms_iff_atom_in_db V V_Eqb V_Eqb_ok lt succ V_default
+      { apply (proj1 (in_db_to_atoms_iff_atom_in_db V V_Eqb V_Eqb_ok lt succ V_default V_leb
                         V V_Eqb V_Eqb_ok V_map V_map_ok V_trie V_trie_ok A (Defs.db e_assum))).
         exact HA_in. }
       (* Step C: case split on atom_fn A = sort_of *)
@@ -1470,7 +1471,7 @@ Section WithVar.
       split; [exact Hsnd_concl|].
       split; [exact Hai2|].
       intros al Hin_al.
-      exact (QueryOptSound.atom_sound_extend V lt succ V_default V V_map (lang_model l)
+      exact (QueryOptSound.atom_sound_extend V lt succ V_default V_leb V V_map (lang_model l)
                i1 i2 al Hext12 (egraph_atoms_sound i1 _ Hsnd_i1 al Hin_al)).
     Qed.
 
@@ -1520,7 +1521,7 @@ Section WithVar.
            V_map V_map_ok V_map V_trie V_trie_ok) as Hira.
         pose proof (Hira X (db_to_atoms (db e_assum)) e_concl a0 Ha0) as Hin_concl.
         exact (in_all _ _ _
-          (@QueryOptSound.db_to_atoms_sound V V_Eqb V_Eqb_ok lt succ V_default V V_Eqb V_Eqb_ok
+          (@QueryOptSound.db_to_atoms_sound V V_Eqb V_Eqb_ok lt succ V_default V_leb V V_Eqb V_Eqb_ok
              V_map V_map_ok V_map V_trie V_trie_ok (lang_model l) i2 e_concl Hsnd)
           (in_map (@atom_clause V V) _ _ Hin_concl)).
     Qed.
@@ -1588,7 +1589,7 @@ Section WithVar.
       subst cl.
       cbn [clause_vars] in Hk_in.
       assert (HA : @Semantics.atom_in_egraph V V V_map V_map V_trie X A e_assum).
-      { apply (proj1 (in_db_to_atoms_iff_atom_in_db V V_Eqb V_Eqb_ok lt succ V_default
+      { apply (proj1 (in_db_to_atoms_iff_atom_in_db V V_Eqb V_Eqb_ok lt succ V_default V_leb
                         V V_Eqb V_Eqb_ok V_map V_map_ok V_trie V_trie_ok A (Defs.db e_assum))).
         exact HA_in. }
       destruct (eqb (Defs.atom_fn A) sort_of) eqn:Heqfn.
@@ -1847,7 +1848,7 @@ Section WithVar.
           (QueryOpt.optimize_sequent V V_Eqb succ V_default V V_map V_map V_trie
              (rule_to_log_seq name (term_rule c args t)) rf).
     Proof.
-      apply (@optimize_sequent_forward_atoms V V_Eqb V_Eqb_ok lt succ V_default
+      apply (@optimize_sequent_forward_atoms V V_Eqb V_Eqb_ok lt succ V_default V_leb
                V V_Eqb V_Eqb_ok V_map V_map_ok V_map V_map_ok V_trie V_trie_ok
                (rule_to_log_seq name (term_rule c args t)) rf (lang_model l)
                (@Theorems.lang_model_ok V V_Eqb V_Eqb_ok sort_of l Hsof Hwf)
@@ -1871,7 +1872,7 @@ Section WithVar.
           (QueryOpt.optimize_sequent V V_Eqb succ V_default V V_map V_map V_trie
              (rule_to_log_seq name (sort_rule c args)) rf).
     Proof.
-      apply (@optimize_sequent_forward_atoms V V_Eqb V_Eqb_ok lt succ V_default
+      apply (@optimize_sequent_forward_atoms V V_Eqb V_Eqb_ok lt succ V_default V_leb
                V V_Eqb V_Eqb_ok V_map V_map_ok V_map V_map_ok V_trie V_trie_ok
                (rule_to_log_seq name (sort_rule c args)) rf (lang_model l)
                (@Theorems.lang_model_ok V V_Eqb V_Eqb_ok sort_of l Hsof Hwf)
@@ -2156,7 +2157,7 @@ Section WithVar.
       split; [exact Hsnd_concl|].
       split; [exact Hai2|].
       intros al Hin_al.
-      exact (QueryOptSound.atom_sound_extend V lt succ V_default V V_map (lang_model l)
+      exact (QueryOptSound.atom_sound_extend V lt succ V_default V_leb V V_map (lang_model l)
                i1 i2 al Hext12 (egraph_atoms_sound i1 _ Hsnd_i1 al Hin_al)).
     Qed.
 
@@ -2223,7 +2224,7 @@ Section WithVar.
            V_map V_map_ok V_map V_trie V_trie_ok) as Hira.
         pose proof (Hira X (db_to_atoms (db e_assum_c)) e_concl_c a0 Ha0) as Hin_concl.
         exact (in_all _ _ _
-          (@QueryOptSound.db_to_atoms_sound V V_Eqb V_Eqb_ok lt succ V_default V V_Eqb V_Eqb_ok
+          (@QueryOptSound.db_to_atoms_sound V V_Eqb V_Eqb_ok lt succ V_default V_leb V V_Eqb V_Eqb_ok
              V_map V_map_ok V_map V_trie V_trie_ok (lang_model l) i2 e_concl_c Hsnd)
           (in_map (@atom_clause V V) _ _ Hin_concl)).
     Qed.
@@ -2290,7 +2291,7 @@ Section WithVar.
       rewrite in_map_iff in Hcl_in. destruct Hcl_in as (A & Hcl_eq & HA_in).
       subst cl. cbn [clause_vars] in Hk_in.
       assert (HA : @Semantics.atom_in_egraph V V V_map V_map V_trie X A e_assum_c).
-      { apply (proj1 (in_db_to_atoms_iff_atom_in_db V V_Eqb V_Eqb_ok lt succ V_default
+      { apply (proj1 (in_db_to_atoms_iff_atom_in_db V V_Eqb V_Eqb_ok lt succ V_default V_leb
                         V V_Eqb V_Eqb_ok V_map V_map_ok V_trie V_trie_ok A (Defs.db e_assum_c))).
         exact HA_in. }
       assert (HA_uf : @Semantics.atom_in_egraph V V V_map V_map V_trie X A
@@ -2635,7 +2636,7 @@ Section WithVar.
           (QueryOpt.optimize_sequent V V_Eqb succ V_default V V_map V_map V_trie
              (rule_to_log_seq name (term_eq_rule c e1 e2 t)) rf).
     Proof.
-      apply (@optimize_sequent_forward_atoms V V_Eqb V_Eqb_ok lt succ V_default
+      apply (@optimize_sequent_forward_atoms V V_Eqb V_Eqb_ok lt succ V_default V_leb
                V V_Eqb V_Eqb_ok V_map V_map_ok V_map V_map_ok V_trie V_trie_ok
                (rule_to_log_seq name (term_eq_rule c e1 e2 t)) rf (lang_model l)
                (@Theorems.lang_model_ok V V_Eqb V_Eqb_ok sort_of l Hsof Hwf)
@@ -2950,7 +2951,7 @@ Section WithVar.
       split; [exact Hsnd_concl|].
       split; [exact Hai2|].
       intros al Hin_al.
-      exact (QueryOptSound.atom_sound_extend V lt succ V_default V V_map (lang_model l)
+      exact (QueryOptSound.atom_sound_extend V lt succ V_default V_leb V V_map (lang_model l)
                i1 i2 al Hext12 (egraph_atoms_sound i1 _ Hsnd_i1 al Hin_al)).
     Qed.
 
@@ -3015,7 +3016,7 @@ Section WithVar.
            V_map V_map_ok V_map V_trie V_trie_ok) as Hira.
         pose proof (Hira X (db_to_atoms (db e_assum_c)) e_concl_c a0 Ha0) as Hin_concl.
         exact (in_all _ _ _
-          (@QueryOptSound.db_to_atoms_sound V V_Eqb V_Eqb_ok lt succ V_default V V_Eqb V_Eqb_ok
+          (@QueryOptSound.db_to_atoms_sound V V_Eqb V_Eqb_ok lt succ V_default V_leb V V_Eqb V_Eqb_ok
              V_map V_map_ok V_map V_trie V_trie_ok (lang_model l) i2 e_concl_c Hsnd)
           (in_map (@atom_clause V V) _ _ Hin_concl)).
     Qed.
@@ -3079,7 +3080,7 @@ Section WithVar.
       rewrite in_map_iff in Hcl_in. destruct Hcl_in as (A & Hcl_eq & HA_in).
       subst cl. cbn [clause_vars] in Hk_in.
       assert (HA : @Semantics.atom_in_egraph V V V_map V_map V_trie X A e_assum_c).
-      { apply (proj1 (in_db_to_atoms_iff_atom_in_db V V_Eqb V_Eqb_ok lt succ V_default
+      { apply (proj1 (in_db_to_atoms_iff_atom_in_db V V_Eqb V_Eqb_ok lt succ V_default V_leb
                         V V_Eqb V_Eqb_ok V_map V_map_ok V_trie V_trie_ok A (Defs.db e_assum_c))).
         exact HA_in. }
       assert (HA_uf : @Semantics.atom_in_egraph V V V_map V_map V_trie X A
@@ -3411,7 +3412,7 @@ Section WithVar.
           (QueryOpt.optimize_sequent V V_Eqb succ V_default V V_map V_map V_trie
              (rule_to_log_seq name (sort_eq_rule c t1 t2)) rf).
     Proof.
-      apply (@optimize_sequent_forward_atoms V V_Eqb V_Eqb_ok lt succ V_default
+      apply (@optimize_sequent_forward_atoms V V_Eqb V_Eqb_ok lt succ V_default V_leb
                V V_Eqb V_Eqb_ok V_map V_map_ok V_map V_map_ok V_trie V_trie_ok
                (rule_to_log_seq name (sort_eq_rule c t1 t2)) rf (lang_model l)
                (@Theorems.lang_model_ok V V_Eqb V_Eqb_ok sort_of l Hsof Hwf)

--- a/src/Pyrosome/Tools/EGraph/Automation.v
+++ b/src/Pyrosome/Tools/EGraph/Automation.v
@@ -104,10 +104,10 @@ Section ReducingSkeleton.
     (list (nat * rule_set positive positive TrieMap.trie_map TrieMap.trie_map)).
   Local Notation red_cong :=
     (Defs.egraph_reducing_cong TrieMap.ptree_map_plus (@FullPosTrie.full_pos_trie_map)
-       Pos.succ PosListMap.sort_of (@fpt_spaced_intersect)).
+       Pos.succ Pos.leb PosListMap.sort_of (@fpt_spaced_intersect)).
   Local Notation red_eq_step :=
     (Defs.egraph_reducing_equal_step TrieMap.ptree_map_plus (@FullPosTrie.full_pos_trie_map)
-       Pos.succ PosListMap.sort_of (@fpt_spaced_intersect)).
+       Pos.succ Pos.leb PosListMap.sort_of (@fpt_spaced_intersect)).
 
   (* The real Phase-3/6 interface (no longer a placeholder): [sort_of] is
      fresh in [l'] (guaranteed by the renaming, which reserves position 1),
@@ -119,7 +119,7 @@ Section ReducingSkeleton.
   Definition schedule_sound (l' : lang positive) (sched : pos_schedule) : Prop :=
     fresh PosListMap.sort_of l' /\
     @ReducingCong.schedule_sound_real positive positive_Eqb positive_default
-      TrieMap.trie_map TrieMap.ptree_map_plus (@FullPosTrie.full_pos_trie_map) Pos.succ
+      TrieMap.trie_map TrieMap.ptree_map_plus (@FullPosTrie.full_pos_trie_map) Pos.succ Pos.leb
       PosListMap.sort_of Pos.lt (@fpt_spaced_intersect) l' sched.
 
   (* The egraph-soundness lemmas require [map.ok] of the egraph's maps.  For
@@ -193,7 +193,7 @@ Section ReducingSkeleton.
     pose proof (@ReducingCong.egraph_reducing_cong_sound positive positive_Eqb positive_Eqb_ok
                   positive_default TrieMap.trie_map TrieMap.ptree_map_plus (@TrieMapFold.trie_map_ok)
                   TrieMap.ptree_map_plus_ok (@FullPosTrie.full_pos_trie_map) (@FullPosTrie.full_pos_trie_map_ok)
-                  Pos.succ PosListMap.sort_of Pos.lt
+                  Pos.succ Pos.leb PosListMap.sort_of Pos.lt
                   pos_lt_asym Pos.lt_succ_diag_r Pos.lt_trans
                   (@fpt_spaced_intersect) l' Hwf Hfresh sched rfuel sat_fuel efuel Hsched
                   red_fuel inj goals Hwfgoals Hsucc) as Hconc.
@@ -373,7 +373,7 @@ Section ReducingSkeleton.
                   positive positive_Eqb positive_Eqb_ok positive_default
                   TrieMap.trie_map TrieMap.ptree_map_plus (fun A => @TrieMapFold.trie_map_ok A)
                   (@FullPosTrie.full_pos_trie_map) (fun A => @FullPosTrie.full_pos_trie_map_ok A)
-                  Pos.succ PosListMap.sort_of Pos.lt pos_lt_asym Pos.lt_succ_diag_r Pos.lt_trans
+                  Pos.succ Pos.leb PosListMap.sort_of Pos.lt pos_lt_asym Pos.lt_succ_diag_r Pos.lt_trans
                   Lp HwfLp Hsof rebuild_fuel posR rsR Hincl_R Hbrs1)
         as (seqsR & HrsR_eq & HmsrR).
       (* Get seqsRR and HmsrRR *)
@@ -381,7 +381,7 @@ Section ReducingSkeleton.
                   positive positive_Eqb positive_Eqb_ok positive_default
                   TrieMap.trie_map TrieMap.ptree_map_plus (fun A => @TrieMapFold.trie_map_ok A)
                   (@FullPosTrie.full_pos_trie_map) (fun A => @FullPosTrie.full_pos_trie_map_ok A)
-                  Pos.succ PosListMap.sort_of Pos.lt pos_lt_asym Pos.lt_succ_diag_r Pos.lt_trans
+                  Pos.succ Pos.leb PosListMap.sort_of Pos.lt pos_lt_asym Pos.lt_succ_diag_r Pos.lt_trans
                   Lp HwfLp Hsof rebuild_fuel posRR rsRR Hrev_RR Hbrs2)
         as (seqsRR & HrsRR_eq & HmsrRR).
       (* Now prove schedule_sound *)
@@ -403,7 +403,7 @@ Section ReducingSkeleton.
           - (* const conjunct *)
             intros e i Hok Hsnd.
             exact (@QueryOptSound.rs_saturation_const_conjunct
-                     positive positive_Eqb positive_Eqb_ok Pos.lt Pos.succ positive_default
+                     positive positive_Eqb positive_Eqb_ok Pos.lt Pos.succ positive_default Pos.leb
                      positive positive_Eqb positive_Eqb_ok
                      TrieMap.trie_map (fun A => @TrieMapFold.trie_map_ok A) TrieMap.ptree_map_plus
                      TrieMap.trie_map (fun A => @TrieMapFold.trie_map_ok A)
@@ -413,9 +413,9 @@ Section ReducingSkeleton.
                      Hmok pos_lt_asym Pos.lt_succ_diag_r Pos.lt_trans
                      rebuild_fuel seqsR HmsrR i e Hok Hsnd).
           - (* per-rule conjunct *)
-            intros e er Hin_er.
+            intros w e er Hin_er.
             apply (@QueryOptSound.compiled_rules_run1iter_rule_hyps
-                     positive positive_Eqb positive_Eqb_ok Pos.lt Pos.succ positive_default
+                     positive positive_Eqb positive_Eqb_ok Pos.lt Pos.succ positive_default Pos.leb
                      positive positive_Eqb positive_Eqb_ok
                      TrieMap.trie_map (fun A => @TrieMapFold.trie_map_ok A) TrieMap.ptree_map_plus
                      TrieMap.trie_map TrieMap.ptree_map_plus
@@ -425,10 +425,11 @@ Section ReducingSkeleton.
                      TrieMap.ptree_map_plus_ok
                      (@fpt_spaced_intersect)
                      (option positive) (@Defs.depth positive)
+                     w
                      (Theorems.lang_model positive PosListMap.sort_of Lp)
                      Hmok rebuild_fuel seqsR er e HmsrR Hin_er).
-            + exact (QcAlignment.trie_join_H9_sn rebuild_fuel seqsR er Hin_er e).
-            + exact (QcAlignment.trie_join_H10_sn rebuild_fuel seqsR er Hin_er e).
+            + exact (QcAlignment.trie_join_H9_sn rebuild_fuel seqsR er Hin_er e w).
+            + exact (QcAlignment.trie_join_H10_sn rebuild_fuel seqsR er Hin_er e w).
         }
         destruct HIn' as [E | HEmpty].
         { (* n=1, rs=rsRR *)
@@ -439,7 +440,7 @@ Section ReducingSkeleton.
           - (* const conjunct *)
             intros e i Hok Hsnd.
             exact (@QueryOptSound.rs_saturation_const_conjunct
-                     positive positive_Eqb positive_Eqb_ok Pos.lt Pos.succ positive_default
+                     positive positive_Eqb positive_Eqb_ok Pos.lt Pos.succ positive_default Pos.leb
                      positive positive_Eqb positive_Eqb_ok
                      TrieMap.trie_map (fun A => @TrieMapFold.trie_map_ok A) TrieMap.ptree_map_plus
                      TrieMap.trie_map (fun A => @TrieMapFold.trie_map_ok A)
@@ -449,9 +450,9 @@ Section ReducingSkeleton.
                      Hmok pos_lt_asym Pos.lt_succ_diag_r Pos.lt_trans
                      rebuild_fuel seqsRR HmsrRR i e Hok Hsnd).
           - (* per-rule conjunct *)
-            intros e er Hin_er.
+            intros w e er Hin_er.
             apply (@QueryOptSound.compiled_rules_run1iter_rule_hyps
-                     positive positive_Eqb positive_Eqb_ok Pos.lt Pos.succ positive_default
+                     positive positive_Eqb positive_Eqb_ok Pos.lt Pos.succ positive_default Pos.leb
                      positive positive_Eqb positive_Eqb_ok
                      TrieMap.trie_map (fun A => @TrieMapFold.trie_map_ok A) TrieMap.ptree_map_plus
                      TrieMap.trie_map TrieMap.ptree_map_plus
@@ -461,10 +462,11 @@ Section ReducingSkeleton.
                      TrieMap.ptree_map_plus_ok
                      (@fpt_spaced_intersect)
                      (option positive) (@Defs.depth positive)
+                     w
                      (Theorems.lang_model positive PosListMap.sort_of Lp)
                      Hmok rebuild_fuel seqsRR er e HmsrRR Hin_er).
-            + exact (QcAlignment.trie_join_H9_sn rebuild_fuel seqsRR er Hin_er e).
-            + exact (QcAlignment.trie_join_H10_sn rebuild_fuel seqsRR er Hin_er e).
+            + exact (QcAlignment.trie_join_H9_sn rebuild_fuel seqsRR er Hin_er e w).
+            + exact (QcAlignment.trie_join_H10_sn rebuild_fuel seqsRR er Hin_er e w).
         }
         destruct HEmpty.
     }

--- a/src/Pyrosome/Tools/EGraph/Automation.v
+++ b/src/Pyrosome/Tools/EGraph/Automation.v
@@ -427,8 +427,8 @@ Section ReducingSkeleton.
                      (option positive) (@Defs.depth positive)
                      (Theorems.lang_model positive PosListMap.sort_of Lp)
                      Hmok rebuild_fuel seqsR er e HmsrR Hin_er).
-            + exact (QcAlignment.trie_join_H9 rebuild_fuel seqsR er Hin_er e).
-            + exact (QcAlignment.trie_join_H10 rebuild_fuel seqsR er Hin_er e).
+            + exact (QcAlignment.trie_join_H9_sn rebuild_fuel seqsR er Hin_er e).
+            + exact (QcAlignment.trie_join_H10_sn rebuild_fuel seqsR er Hin_er e).
         }
         destruct HIn' as [E | HEmpty].
         { (* n=1, rs=rsRR *)
@@ -463,8 +463,8 @@ Section ReducingSkeleton.
                      (option positive) (@Defs.depth positive)
                      (Theorems.lang_model positive PosListMap.sort_of Lp)
                      Hmok rebuild_fuel seqsRR er e HmsrRR Hin_er).
-            + exact (QcAlignment.trie_join_H9 rebuild_fuel seqsRR er Hin_er e).
-            + exact (QcAlignment.trie_join_H10 rebuild_fuel seqsRR er Hin_er e).
+            + exact (QcAlignment.trie_join_H9_sn rebuild_fuel seqsRR er Hin_er e).
+            + exact (QcAlignment.trie_join_H10_sn rebuild_fuel seqsRR er Hin_er e).
         }
         destruct HEmpty.
     }

--- a/src/Pyrosome/Tools/EGraph/Defs.v
+++ b/src/Pyrosome/Tools/EGraph/Defs.v
@@ -87,7 +87,11 @@ Section WithVar.
   Notation atom := (atom V V).
 
   Context (succ : V -> V).
-  
+
+  (* epoch order for the semi-naive "new" window (passed to Utils.saturate_until);
+     all instantiations provide a real <= (e.g. Pos.leb). *)
+  Context (V_leb : V -> V -> bool).
+
   (* Include sort_of as special symbol/fn in db. *)
   Context (sort_of : V).
 
@@ -659,15 +663,21 @@ Section WithVar.
     
     (*TODO: move to Utils.EGraph.Defs *)
     Fixpoint scheduled_saturate_until rfuel
-      {X} `{analysis V V X} 
+      {X} `{analysis V V X}
        schedule p fuel
       : state (Defs.instance V V _ _ _ X) bool :=
+      (* Total schedule weight = max epoch ticks in one outer pass.  When row [e]
+         fires, every OTHER row fired since [e] last ran, advancing the epoch by at
+         most [W_total - fst e] ticks; so its catch-up "new" window is exactly that.
+         This makes a phase re-match every fact added since it last fired, fixing
+         the cross-phase incompleteness of plain semi-naive. *)
+      let W_total := list_sum (map fst schedule) in
       match fuel with
       | 0 => Mret false
       | S fuel =>
           let process e : state (Defs.instance V V _ _ _ X) bool :=
-            saturate_until succ V_default (analysis_result:= X)
-              spaced_list_intersect rfuel (snd e) p (fst e) in
+            saturate_until succ V_default V_leb (analysis_result:= X)
+              spaced_list_intersect rfuel (W_total - fst e) (snd e) p (fst e) in
           @! let (done : bool) <- list_Miter_breakable process schedule in
             if done then ret true
             else (scheduled_saturate_until rfuel schedule p fuel)
@@ -709,9 +719,9 @@ Section WithVar.
         @!let {state instance} x <- add_open_term l true false [] e in
           let w <- get_analysis x in
           let {state instance} _ <- rebuild rfuel in
-          let {state instance} _ <- saturate_until succ V_default
+          let {state instance} _ <- saturate_until succ V_default V_leb
                                       (*TODO: short-circuit as soon as the subject weight decreases*)
-        spaced_list_intersect rfuel rws (weight_less_than x w) fuel in
+        spaced_list_intersect rfuel 0 rws (weight_less_than x w) fuel in
           ret {state instance} x
       in
       let (x,g) := comp (empty_egraph default _) in
@@ -856,11 +866,11 @@ Section WithVar.
         rfuel sat_fuel efuel red_fuel inj_list [(e1,e2)].
 
     (*TODO: move to defining file*)
-    Arguments run1iter {idx}%_type_scope {Eqb_idx} idx_succ%_function_scope 
-      idx_zero {symbol}%_type_scope {symbol_map}%_function_scope {symbol_map_plus}
-      {idx_map}%_function_scope {idx_map_plus} {idx_trie}%_function_scope 
+    Arguments run1iter {idx}%_type_scope {Eqb_idx} idx_succ%_function_scope
+      idx_zero idx_leb%_function_scope {symbol}%_type_scope {symbol_map}%_function_scope {symbol_map_plus}
+      {idx_map}%_function_scope {idx_map_plus} {idx_trie}%_function_scope
       {analysis_result}%_type_scope {H} spaced_list_intersect%_function_scope
-      rebuild_fuel%_nat_scope rs _.
+      rebuild_fuel%_nat_scope window%_nat_scope rs _.
 
     (*
     Fixpoint egraph_simpl_capped'
@@ -885,7 +895,7 @@ Section WithVar.
       match cap with
       | O => Mret error:("Terms not reduced within" cap "iterations")
       | S cap =>
-          @! let _ <- lift (run1iter succ _ spaced_list_intersect rn rws) in
+          @! let _ <- lift (run1iter succ _ V_leb spaced_list_intersect rn 0 rws) in
             let e1' <- get_extract en x1 in
             let _ <- lift (log_event cap) in
             let _ <- lift (log_event "extracted e1 and e2. cap is") in
@@ -935,17 +945,17 @@ Module PositiveInstantiation.
   Definition egraph_equal
     : lang positive -> _ -> nat ->
       nat -> Term.term positive -> Term.term positive -> Term.sort positive -> _ :=
-    (egraph_equal ptree_map_plus (@FullPosTrie.full_pos_trie_map) Pos.succ sort_of (@fpt_spaced_intersect)).
+    (egraph_equal ptree_map_plus (@FullPosTrie.full_pos_trie_map) Pos.succ Pos.leb sort_of (@fpt_spaced_intersect)).
 
   Definition egraph_simpl
     : lang positive -> _ -> nat -> nat ->
       nat -> Term.term positive -> _ :=
-    (egraph_simpl ptree_map_plus (@FullPosTrie.full_pos_trie_map) Pos.succ sort_of (@fpt_spaced_intersect)).
+    (egraph_simpl ptree_map_plus (@FullPosTrie.full_pos_trie_map) Pos.succ Pos.leb sort_of (@fpt_spaced_intersect)).
 
   Definition egraph_reducing_equal
     : lang positive -> _ -> _ -> nat ->
       nat -> nat -> nat -> Term.term positive -> Term.term positive -> _ :=
-    (egraph_reducing_equal ptree_map_plus (@FullPosTrie.full_pos_trie_map) Pos.succ sort_of (@fpt_spaced_intersect)).
+    (egraph_reducing_equal ptree_map_plus (@FullPosTrie.full_pos_trie_map) Pos.succ Pos.leb sort_of (@fpt_spaced_intersect)).
 
   (*TODO: move somewhere?*)
   Definition filter_eqn_rules {V} : lang V -> lang V :=
@@ -1097,7 +1107,10 @@ Module StringInstantiation.
     fun l rw rn n en c e1 e2 t =>
     let l' := ctx_to_rules c ++ l in
     egraph_equal string_ptree_map_plus (@string_list_trie_map)
-      string_succ sort_of
+      string_succ (* epoch leb: the string reference engine runs naive
+        (every row "new") since a precise order on string_succ's little-endian
+        numeric suffix isn't worth implementing here; naive is complete+sound. *)
+      (fun _ _ => true) sort_of
       (@PosListMap.compat_intersect) l' [(n,rw)] rn 1
       (var_to_con e1) (var_to_con e2) (sort_var_to_con t).
   

--- a/src/Pyrosome/Tools/EGraph/ReducingCong.v
+++ b/src/Pyrosome/Tools/EGraph/ReducingCong.v
@@ -30,7 +30,7 @@ Section ReducingStep.
     (V_map_plus_ok : ExtraMaps.map_plus_ok V_map)
     (V_trie : forall A, map.map (list V) A)
     (V_trie_ok : forall A, map.ok (V_trie A)).
-  Context (succ : V -> V) (sort_of : V) (lt : V -> V -> Prop).
+  Context (succ : V -> V) (V_leb : V -> V -> bool) (sort_of : V) (lt : V -> V -> Prop).
   Context (lt_asymmetric : Asymmetric lt)
     (lt_succ : forall x, lt x (succ x))
     (lt_trans : Transitive lt).
@@ -344,7 +344,7 @@ Section ReducingStep.
     Definition schedule_sound_real
       (schedule : list (nat * rule_set V V V_map V_map)) : Prop :=
       forall n rs, In (n, rs) schedule ->
-        @rs_saturation_hyps V V_Eqb V_default V_map V_map_plus V_trie succ lt
+        @rs_saturation_hyps V V_Eqb V_default V_map V_map_plus V_trie succ V_leb lt
           (option positive) (depth V) spaced_list_intersect lang_model rs.
 
     (* Stronger form, exposing the resulting egraph's soundness and the input
@@ -362,7 +362,7 @@ Section ReducingStep.
       wf_term l [] a ta -> wf_term l [] b tb ->
       schedule_sound_real schedule ->
       let '(res, x1, x2, g) :=
-        egraph_reducing_equal_step V_map_plus V_trie succ sort_of spaced_list_intersect
+        egraph_reducing_equal_step V_map_plus V_trie succ V_leb sort_of spaced_list_intersect
           l schedule rfuel sat_fuel a b in
       exists i,
         egraph_ok g /\ sound i g
@@ -378,8 +378,8 @@ Section ReducingStep.
       destruct (get_analysis V V V_map V_map V_trie (option positive) x2 e1) as [w2 e2] eqn:Hga2.
       destruct (rebuild rfuel e2) as [u e3] eqn:Hrb.
       match goal with
-      | |- context [scheduled_saturate_until ?vmp ?sc ?sli ?rf ?sch ?p ?sf ?e] =>
-          destruct (scheduled_saturate_until vmp sc sli rf sch p sf e) as [res g] eqn:Hsat
+      | |- context [scheduled_saturate_until ?vmp ?sc ?vleb ?sli ?rf ?sch ?p ?sf ?e] =>
+          destruct (scheduled_saturate_until vmp sc vleb sli rf sch p sf e) as [res g] eqn:Hsat
       end.
       cbn [fst snd].
       pose proof (@empty_sound_for_interpretation V lt succ V_default V V_map V_map_ok V_map V_map_ok V_trie (option positive) lang_model) as Hempty.
@@ -423,7 +423,7 @@ Section ReducingStep.
       rewrite Hrb in Hrbs; cbn [snd] in Hrbs; destruct Hrbs as [Hok_e3 Hiff3].
       assert (Hsnd_e3 : sound i2 e3) by (apply (Hiff3 i2); exact Hsnd_e2).
       match type of Hsat with
-      | scheduled_saturate_until _ _ _ _ _ ?p _ _ = _ => set (pred := p) in *
+      | scheduled_saturate_until _ _ _ _ _ _ ?p _ _ = _ => set (pred := p) in *
       end.
       assert (HP : forall ee ii, egraph_ok ee -> sound ii ee -> egraph_ok (snd (pred ee)) /\ sound ii (snd (pred ee)))
         by (intros ee ii Hoke Hsnde; subst pred; unfold weight_less_than;
@@ -441,7 +441,7 @@ Section ReducingStep.
             [ cbn [snd]; split; assumption | ];
             pose proof (@are_unified_preserves_ok_sound V V_Eqb V_Eqb_ok lt succ V_default V V_map V_map V_map_ok V_trie (option positive) lang_model x1 x2 e2' ii Hok2 Hsnd2) as Hau;
             destruct Hau as [ Hoku Hsndu ]; split; assumption).
-      pose proof (@scheduled_saturate_until_sound V V_Eqb V_Eqb_ok V_default V_map V_map_plus V_map_ok V_trie V_trie_ok succ lt lt_asymmetric lt_succ lt_trans V_map_plus_ok (option positive) (depth V) spaced_list_intersect lang_model Hmok rfuel pred HP schedule Hsched sat_fuel i2 e3 Hok_e3 Hsnd_e3) as Hss.
+      pose proof (@scheduled_saturate_until_sound V V_Eqb V_Eqb_ok V_default V_map V_map_plus V_map_ok V_trie V_trie_ok succ V_leb lt lt_asymmetric lt_succ lt_trans V_map_plus_ok (option positive) (depth V) spaced_list_intersect lang_model Hmok rfuel pred HP schedule Hsched sat_fuel i2 e3 Hok_e3 Hsnd_e3) as Hss.
       rewrite Hsat in Hss.
       destruct Hss as [ Hok_g [ i3 [ Hext3 Hsnd_g ] ] ].
       pose proof (Hlift i2 i3 x1 (inl a) Hext3 (Hlift i1 i2 x1 (inl a) Hextmap2 Hrel1)) as Hr1g.
@@ -653,7 +653,7 @@ Section CongMain.
     (V_map_plus_ok : ExtraMaps.map_plus_ok V_map)
     (V_trie : forall A, map.map (list V) A)
     (V_trie_ok : forall A, map.ok (V_trie A)).
-  Context (succ : V -> V) (sort_of : V) (lt : V -> V -> Prop).
+  Context (succ : V -> V) (V_leb : V -> V -> bool) (sort_of : V) (lt : V -> V -> Prop).
   Context (lt_asymmetric : Asymmetric lt)
     (lt_succ : forall x, lt x (succ x))
     (lt_trans : Transitive lt).
@@ -749,10 +749,10 @@ Section CongMain.
   Lemma egraph_reducing_cong_sound
     (schedule : list (nat * rule_set V V V_map V_map))
     (rfuel sat_fuel efuel : nat) :
-    schedule_sound_real V V_map V_map_plus V_trie succ sort_of lt spaced_list_intersect l schedule ->
+    schedule_sound_real V V_map V_map_plus V_trie succ V_leb sort_of lt spaced_list_intersect l schedule ->
     forall red_fuel inj goals,
       (forall a b, In (a,b) goals -> (exists ta, wf_term l [] a ta) /\ (exists tb, wf_term l [] b tb)) ->
-      egraph_reducing_cong V_map_plus V_trie succ sort_of spaced_list_intersect l schedule rfuel sat_fuel efuel red_fuel inj goals = Result.Success tt ->
+      egraph_reducing_cong V_map_plus V_trie succ V_leb sort_of spaced_list_intersect l schedule rfuel sat_fuel efuel red_fuel inj goals = Result.Success tt ->
       forall a b, In (a,b) goals -> exists s, eq_term l [] s a b.
   Proof.
     intros Hsched red_fuel.
@@ -768,9 +768,9 @@ Section CongMain.
         pose proof (in_all _ _ _ Hwfsub Hinsub) as Hwfp.
         cbn [fst snd] in Hwfp. destruct Hwfp as [ [se1 Hwfe1] [se2 Hwfe2] ].
         cbn beta iota in Hproc.
-        pose proof (egraph_reducing_equal_step_sound_strong V V_map V_map_plus V_map_ok V_map_plus_ok V_trie V_trie_ok succ sort_of lt lt_asymmetric lt_succ lt_trans spaced_list_intersect l wfl sort_of_fresh schedule rfuel sat_fuel e1 e2 se1 se2 Hwfe1 Hwfe2 Hsched) as Hstrong.
+        pose proof (egraph_reducing_equal_step_sound_strong V V_map V_map_plus V_map_ok V_map_plus_ok V_trie V_trie_ok succ V_leb sort_of lt lt_asymmetric lt_succ lt_trans spaced_list_intersect l wfl sort_of_fresh schedule rfuel sat_fuel e1 e2 se1 se2 Hwfe1 Hwfe2 Hsched) as Hstrong.
         revert Hproc Hstrong.
-        destruct (egraph_reducing_equal_step V_map_plus V_trie succ sort_of spaced_list_intersect l schedule rfuel sat_fuel e1 e2) as [ [ [res x] y] g].
+        destruct (egraph_reducing_equal_step V_map_plus V_trie succ V_leb sort_of spaced_list_intersect l schedule rfuel sat_fuel e1 e2) as [ [ [res x] y] g].
         intros Hproc [i [Hokg [Hsndg [Hr1 Hr2] ] ] ].
         destruct res; [ | discriminate Hproc ].
         assert (Hisx : Is_Some (map.get i x)) by (unfold option_relation in Hr1; destruct (map.get i x); [ exact I | discriminate Hr1 ]).

--- a/src/Pyrosome/Tools/EGraph/SchedSat.v
+++ b/src/Pyrosome/Tools/EGraph/SchedSat.v
@@ -74,6 +74,9 @@ Section WithVar.
 
   Context (succ : V -> V).
 
+  (* epoch order for the semi-naive "new" window *)
+  Context (V_leb : V -> V -> bool).
+
   (* Include sort_of as special symbol/fn in db. *)
   Context (sort_of : V).
 
@@ -110,19 +113,19 @@ Section WithVar.
       (forall e i, egraph_ok e -> sound i e ->
          egraph_ok (snd (process_const_rules V V_Eqb succ V_default V V_map V_map V_trie X rs e))
          /\ exists i', map.extends i' i /\ sound i' (snd (process_const_rules V V_Eqb succ V_default V V_map V_map V_trie X rs e)))
-      /\ (forall e r, In r (compiled_rules V V V_map V_map rs) ->
-            run1iter_rule_hyps V V_Eqb V_default V V_map V_map_plus V_map V_map_plus V_trie X spaced_list_intersect m rs e r).
+      /\ (forall w e r, In r (compiled_rules V V V_map V_map rs) ->
+            run1iter_rule_hyps V V_Eqb V_default succ V_leb w V V_map V_map_plus V_map V_map_plus V_trie X spaced_list_intersect m rs e r).
 
     (* One pass of the schedule (list_Miter_breakable, stopping at the first
        entry whose termination check fires) is sound: each entry runs
        saturate_until on its rule_set, sound by saturate_until_sound, and the
        interpretations compose. *)
-    Lemma list_Miter_breakable_sound (rfuel : nat) (p : state instance bool)
+    Lemma list_Miter_breakable_sound (rfuel : nat) (W_total : nat) (p : state instance bool)
       (HP : forall e i, egraph_ok e -> sound i e -> egraph_ok (snd (p e)) /\ sound i (snd (p e))) :
       forall (sched : list (nat * rule_set V V V_map V_map)),
       (forall n rs, In (n, rs) sched -> rs_saturation_hyps rs) ->
       forall i e, egraph_ok e -> sound i e ->
-      match list_Miter_breakable (fun entry => saturate_until succ V_default (analysis_result:=X) spaced_list_intersect rfuel (snd entry) p (fst entry)) sched e with
+      match list_Miter_breakable (fun entry => saturate_until succ V_default V_leb (analysis_result:=X) spaced_list_intersect rfuel (W_total - fst entry) (snd entry) p (fst entry)) sched e with
       | (_, e') => egraph_ok e' /\ exists i', map.extends i' i /\ sound i' e'
       end.
     Proof.
@@ -133,18 +136,18 @@ Section WithVar.
         destruct entry as [fuel_i rs_i].
         cbn [fst snd].
         destruct (Hsched fuel_i rs_i (or_introl eq_refl)) as [Hconst_i Hrules_i].
-        pose proof (@saturate_until_sound V V_Eqb V_Eqb_ok lt succ V_default V V_Eqb V_Eqb_ok
+        pose proof (@saturate_until_sound V V_Eqb V_Eqb_ok lt succ V_default V_leb V V_Eqb V_Eqb_ok
                       V_map V_map_plus V_map_plus_ok V_map_ok V_map V_map_plus V_map_ok
                       V_trie V_trie_ok X V_map_plus_ok spaced_list_intersect _ m Hm
-                      lt_asymmetric lt_succ lt_trans rfuel rs_i p HP Hconst_i Hrules_i fuel_i i e Hok Hsnd) as Hsat.
-        destruct (saturate_until succ V_default (analysis_result:=X) spaced_list_intersect rfuel rs_i p fuel_i e) as [break e1] eqn:Hsu.
+                      lt_asymmetric lt_succ lt_trans (W_total - fuel_i) rfuel rs_i p HP Hconst_i Hrules_i fuel_i i e Hok Hsnd) as Hsat.
+        destruct (saturate_until succ V_default V_leb (analysis_result:=X) spaced_list_intersect rfuel (W_total - fuel_i) rs_i p fuel_i e) as [break e1] eqn:Hsu.
         destruct Hsat as (Hok1 & i1 & Hext1 & Hsnd1).
         destruct break.
         + split; [exact Hok1|]. exists i1. split; [exact Hext1 | exact Hsnd1].
         + assert (Hsched' : forall n rs, In (n, rs) sched' -> rs_saturation_hyps rs)
             by (intros n rs Hin; apply (Hsched n rs); right; exact Hin).
           pose proof (IH Hsched' i1 e1 Hok1 Hsnd1) as HIH.
-          destruct (list_Miter_breakable (fun entry => saturate_until succ V_default (analysis_result:=X) spaced_list_intersect rfuel (snd entry) p (fst entry)) sched' e1) as [b e2] eqn:Hlmb.
+          destruct (list_Miter_breakable (fun entry => saturate_until succ V_default V_leb (analysis_result:=X) spaced_list_intersect rfuel (W_total - fst entry) (snd entry) p (fst entry)) sched' e1) as [b e2] eqn:Hlmb.
           destruct HIH as (Hok2 & i2 & Hext2 & Hsnd2).
           split; [exact Hok2|]. exists i2.
           split; [eapply map_extends_trans; [exact Hext2 | exact Hext1] | exact Hsnd2].
@@ -158,7 +161,7 @@ Section WithVar.
       (Hsched : forall n rs, In (n, rs) schedule -> rs_saturation_hyps rs)
       (fuel : nat) :
       forall i e, egraph_ok e -> sound i e ->
-      match scheduled_saturate_until V_map_plus succ spaced_list_intersect rfuel schedule p fuel e with
+      match scheduled_saturate_until V_map_plus succ V_leb spaced_list_intersect rfuel schedule p fuel e with
       | (_, e') => egraph_ok e' /\ exists i', map.extends i' i /\ sound i' e'
       end.
     Proof.
@@ -166,13 +169,13 @@ Section WithVar.
       - cbn [scheduled_saturate_until Mret StateMonad.state_monad].
         split; [exact Hok|]. exists i. split; [apply Properties.map.extends_refl | exact Hsnd].
       - cbn [scheduled_saturate_until Mbind Mret StateMonad.state_monad].
-        pose proof (list_Miter_breakable_sound rfuel p HP schedule Hsched i e Hok Hsnd) as Hlmb.
-        destruct (list_Miter_breakable (fun entry => saturate_until succ V_default (analysis_result:=X) spaced_list_intersect rfuel (snd entry) p (fst entry)) schedule e) as [done e1] eqn:Hlmb_eq.
+        pose proof (list_Miter_breakable_sound rfuel (list_sum (map fst schedule)) p HP schedule Hsched i e Hok Hsnd) as Hlmb.
+        destruct (list_Miter_breakable (fun entry => saturate_until succ V_default V_leb (analysis_result:=X) spaced_list_intersect rfuel (list_sum (map fst schedule) - fst entry) (snd entry) p (fst entry)) schedule e) as [done e1] eqn:Hlmb_eq.
         destruct Hlmb as (Hok1 & i1 & Hext1 & Hsnd1).
         destruct done.
         + split; [exact Hok1|]. exists i1. split; [exact Hext1 | exact Hsnd1].
         + pose proof (IH i1 e1 Hok1 Hsnd1) as HIH.
-          destruct (scheduled_saturate_until V_map_plus succ spaced_list_intersect rfuel schedule p fuel e1) as [b e2] eqn:Hss.
+          destruct (scheduled_saturate_until V_map_plus succ V_leb spaced_list_intersect rfuel schedule p fuel e1) as [b e2] eqn:Hss.
           destruct HIH as (Hok2 & i2 & Hext2 & Hsnd2).
           split; [exact Hok2|]. exists i2.
           split; [eapply map_extends_trans; [exact Hext2 | exact Hext1] | exact Hsnd2].

--- a/src/Pyrosome/Tools/EGraph/TypeInference.v
+++ b/src/Pyrosome/Tools/EGraph/TypeInference.v
@@ -321,11 +321,13 @@ Definition const_rules (l: lang) :=
 Definition state_operation (L: lang) (inj_rules: list (string * list string)) :=
   @saturate_until string String.eqb string_succ
     (default (A:= string))
+    (fun _ _ => true) (* epoch leb: string path runs naive (complete) *)
     string
     string_trie_map
     string_ptree_map_plus string_trie_map string_ptree_map_plus
     string_list_trie_map (option positive) (weighted_depth_analysis weight) (@PosListMap.compat_intersect)
     1000
+    0 (* window *)
     (
     @QueryOpt.build_rule_set string String.eqb string_succ (default (A:= string))
       string  string_trie_map string_ptree_map_plus string_trie_map
@@ -337,11 +339,13 @@ Definition state_operation (L: lang) (inj_rules: list (string * list string)) :=
 Definition state_operation_testing (L: lang) (inj_rules: list (string * list string)) f1 f2 :=
   @saturate_until string String.eqb string_succ
     (default (A:= string))
+    (fun _ _ => true) (* epoch leb: string path runs naive (complete) *)
     string
     string_trie_map
     string_ptree_map_plus string_trie_map string_ptree_map_plus
     string_list_trie_map (option positive) (weighted_depth_analysis weight) (@PosListMap.compat_intersect)
     f1
+    0 (* window *)
     (
     @QueryOpt.build_rule_set string String.eqb string_succ (default (A:= string))
       string  string_trie_map string_ptree_map_plus string_trie_map

--- a/src/Utils/EGraph/BuildTriesDepth.v
+++ b/src/Utils/EGraph/BuildTriesDepth.v
@@ -148,6 +148,7 @@ Section BuildTries.
   Context {idx_map : forall A, map.map positive A} {idx_map_plus : map_plus idx_map}
           {idx_map_plus_ok : @map_plus_ok positive idx_map idx_map_plus}.
   Context {analysis_result : Type}.
+  Context (idx_leb : positive -> positive -> bool).
 
   Notation fptm := (@FullPosTrie.full_pos_trie_map).
 
@@ -162,12 +163,12 @@ Section BuildTries.
                  /\ fpt_depth (snd ft) (clen cl).
 
   Lemma build_tries_for_symbol_depth
-    (current_epoch : positive)
+    (current_epoch : positive) (window : nat)
     (q_clauses : idx_map (list nat * nat))
     (tbl : fptm (db_entry positive analysis_result)) :
     bt_inv q_clauses
-      (build_tries_for_symbol positive _ idx_map idx_map_plus
-         (fun A => fptm A) analysis_result current_epoch q_clauses tbl).
+      (build_tries_for_symbol positive _ Pos.succ idx_leb idx_map idx_map_plus
+         (fun A => fptm A) analysis_result current_epoch window q_clauses tbl).
   Proof.
     unfold build_tries_for_symbol.
     eapply (map.fold_spec (fun _ tries => bt_inv q_clauses tries)).
@@ -185,12 +186,14 @@ Section BuildTries.
       eexists. split; [reflexivity|].
       destruct (match_clause positive positive_Eqb (cargs, cv) k v0) as [assignment|] eqn:Hmc.
       { apply match_clause_length in Hmc.
-        destruct (eqb epoch current_epoch); cbn [fst snd].
-        - split; [|split].
+        destruct (idx_leb current_epoch (Nat.iter window Pos.succ epoch)); cbn [fst snd].
+        - (* within window: full put, new put, old unchanged *)
+          split; [|split].
           + apply fpt_put_depth; [exact Hmc | exact Hdf].
           + apply fpt_put_depth; [exact Hmc | exact Hdn].
           + exact Hdo.
-        - split; [|split].
+        - (* outside window: full put, new unchanged, old put *)
+          split; [|split].
           + apply fpt_put_depth; [exact Hmc | exact Hdf].
           + exact Hdn.
           + apply fpt_put_depth; [exact Hmc | exact Hdo]. }

--- a/src/Utils/EGraph/BuildTriesDepth.v
+++ b/src/Utils/EGraph/BuildTriesDepth.v
@@ -151,12 +151,15 @@ Section BuildTries.
 
   Notation fptm := (@FullPosTrie.full_pos_trie_map).
 
-  (* The fold invariant: every clause key's trie pair is depth-[clen]. *)
+  (* The fold invariant: every clause key's trie triple (full,new,old) is
+     depth-[clen] in all three components. *)
   Definition bt_inv (q_clauses : idx_map (list nat * nat))
-    (tries : idx_map (fptm unit * fptm unit)) : Prop :=
+    (tries : idx_map (fptm unit * fptm unit * fptm unit)) : Prop :=
     forall n cl, map.get q_clauses n = Some cl ->
       exists ft, map.get tries n = Some ft
-                 /\ fpt_depth (fst ft) (clen cl) /\ fpt_depth (snd ft) (clen cl).
+                 /\ fpt_depth (fst (fst ft)) (clen cl)
+                 /\ fpt_depth (snd (fst ft)) (clen cl)
+                 /\ fpt_depth (snd ft) (clen cl).
 
   Lemma build_tries_for_symbol_depth
     (current_epoch : positive)
@@ -168,25 +171,30 @@ Section BuildTries.
   Proof.
     unfold build_tries_for_symbol.
     eapply (map.fold_spec (fun _ tries => bt_inv q_clauses tries)).
-    - intros n cl Hget. exists (map.empty, map.empty).
+    - intros n cl Hget. exists (map.empty, map.empty, map.empty).
       rewrite map_map_spec by exact idx_map_plus_ok. rewrite Hget. cbn [option_map].
       split; [reflexivity|]. cbn [fst snd].
-      unfold map.empty, FullPosTrie.full_pos_trie_map. cbn [fpt_depth]. split; exact I.
+      unfold map.empty, FullPosTrie.full_pos_trie_map. cbn [fpt_depth].
+      split; [exact I | split; [exact I | exact I]].
     - intros k v m r Hgetm Hinv n cl Hget.
       rewrite intersect_spec by exact idx_map_plus_ok.
-      destruct (Hinv n cl Hget) as [ft [Hgetr [Hdf Hds]]].
+      destruct (Hinv n cl Hget) as [ft [Hgetr [Hdf [Hdn Hdo]]]].
       rewrite Hgetr, Hget.
-      destruct v as [epoch v0 a_an]. destruct ft as [full frontier]. cbn [fst snd] in Hdf, Hds.
+      destruct v as [epoch v0 a_an]. destruct ft as [[full new] old]. cbn [fst snd] in Hdf, Hdn, Hdo.
       destruct cl as [cargs cv].
       eexists. split; [reflexivity|].
       destruct (match_clause positive positive_Eqb (cargs, cv) k v0) as [assignment|] eqn:Hmc.
       { apply match_clause_length in Hmc.
-        destruct (eqb epoch current_epoch); cbn [fst snd]; split.
-        - apply fpt_put_depth; [exact Hmc | exact Hdf].
-        - apply fpt_put_depth; [exact Hmc | exact Hds].
-        - apply fpt_put_depth; [exact Hmc | exact Hdf].
-        - exact Hds. }
-      { cbn [fst snd]. split; [exact Hdf | exact Hds]. }
+        destruct (eqb epoch current_epoch); cbn [fst snd].
+        - split; [|split].
+          + apply fpt_put_depth; [exact Hmc | exact Hdf].
+          + apply fpt_put_depth; [exact Hmc | exact Hdn].
+          + exact Hdo.
+        - split; [|split].
+          + apply fpt_put_depth; [exact Hmc | exact Hdf].
+          + exact Hdn.
+          + apply fpt_put_depth; [exact Hmc | exact Hdo]. }
+      { cbn [fst snd]. split; [exact Hdf | split; [exact Hdn | exact Hdo]]. }
   Qed.
 
 End BuildTries.

--- a/src/Utils/EGraph/Defs.v
+++ b/src/Utils/EGraph/Defs.v
@@ -37,6 +37,10 @@ Section WithMap.
       (*TODO: just extend to Natlike?*)
       (idx_succ : idx -> idx)
       (idx_zero : WithDefault idx)
+      (* epoch order, used for the semi-naive "new" window; all instantiations
+         provide a real <= (e.g. Pos.leb).  Needs no correctness spec: the
+         soundness proofs only rely on new <= full, for any boolean split. *)
+      (idx_leb : idx -> idx -> bool)
       (*TODO: any reason to have separate from idx?*)
     (symbol : Type)
       (Eqb_symbol : Eqb symbol)
@@ -524,8 +528,17 @@ Section WithMap.
      Since each (symbol,args) has exactly one entry/epoch, full partitions
      into new (epoch = current) and old (epoch <> current).  The proper
      semi-naive frontier selection picks one of the three by clause position. *)
+  (* [window] is the semi-naive look-back: a db row is "new" iff its [epoch] is
+     within [window] ticks of [current_epoch], i.e. epoch + window >= current_epoch
+     (tested by [idx_leb current_epoch (epoch+window)] since epochs only grow by
+     idx_succ).  [window = 0] gives exactly the single-epoch delta [epoch =
+     current_epoch] (current_epoch is the max present).  The schedule driver passes
+     [window = W_total - w_i] on the FIRST iteration of each phase so it re-matches
+     every fact added since that phase last fired (fixing the cross-phase
+     incompleteness of plain semi-naive); subsequent iterations use [window = 0]. *)
   Definition build_tries_for_symbol
     (current_epoch : idx)
+    (window : nat)
     (q_clauses : idx_map (list nat * nat))
     (tbl : idx_trie db_entry)
     : idx_map (idx_trie unit * idx_trie unit * idx_trie unit) (* full * new * old *)
@@ -537,7 +550,7 @@ Section WithMap.
              TODO: test match_clause
            *)
           let full' : idx_trie unit := map.put full assignment tt in
-          if eqb epoch current_epoch
+          if idx_leb current_epoch (Nat.iter window idx_succ epoch)
           then (full', map.put new assignment tt, old)
           else (full', new, map.put old assignment tt)
       | None => (full, new, old)
@@ -546,9 +559,9 @@ Section WithMap.
     map.fold (fun tries args vp => map_intersect (upd_trie_pair args vp) tries q_clauses)
       (map_map (fun _ => (map.empty, map.empty, map.empty : idx_trie unit)) q_clauses) tbl.
 
-  Definition build_tries (q : rule_set)
+  Definition build_tries (window : nat) (q : rule_set)
     : ST (symbol_map (idx_map (idx_trie unit * idx_trie unit * idx_trie unit))) :=
-    fun i => (map_intersect (build_tries_for_symbol i.(epoch)) q.(query_clauses) i.(db), i).
+    fun i => (map_intersect (build_tries_for_symbol i.(epoch) window) q.(query_clauses) i.(db), i).
 
   Context (spaced_list_intersect
              (*TODO: nary merge?*)
@@ -803,8 +816,8 @@ Section WithMap.
   Definition worklist_empty : ST bool :=
     fun i => (if i.(worklist) then true else false, i).
 
-  Definition run1iter (rs : rule_set) : ST bool :=
-    @!let tries <- build_tries rs in
+  Definition run1iter (window : nat) (rs : rule_set) : ST bool :=
+    @!let tries <- build_tries window rs in
       let old_max <- max_id in
       increment_epoch;
       (list_Miter (process_erule tries) rs.(compiled_rules));
@@ -813,25 +826,28 @@ Section WithMap.
       (* TODO: compute an adequate upper bound for fuel *)
       (rebuild rebuild_fuel);
       ret (andb (eqb new_max old_max) is_empty).
-  
-  Fixpoint saturate_until' rs (P : ST bool) fuel : ST bool :=
+
+  (* [window] is used only by the FIRST iteration (the cross-phase catch-up);
+     every subsequent iteration uses [window = 0] = the ordinary single-epoch
+     delta, since the previous iteration's writes already advanced the epoch. *)
+  Fixpoint saturate_until' window rs (P : ST bool) fuel : ST bool :=
     match fuel with
     | 0 => Mret false
     | S fuel =>
         @!let done <- P in
           if (done : bool) then ret true
           else
-            let no_changes <- run1iter rs in
+            let no_changes <- run1iter window rs in
             (* Short circuit if no new facts were added *)
             if (no_changes : bool) then ret false
-            else (saturate_until' rs P fuel)
+            else (saturate_until' 0 rs P fuel)
     end.
 
   (* run the const rules once before the saturation loop *)
-  Definition saturate_until rs (P : ST bool) fuel : ST bool :=
+  Definition saturate_until window rs (P : ST bool) fuel : ST bool :=
     @! (process_const_rules rs);
        (rebuild rebuild_fuel);
-       (saturate_until' rs P fuel).
+       (saturate_until' window rs P fuel).
     
   
   Definition are_unified (x1 x2 : idx) : state instance bool :=
@@ -861,7 +877,7 @@ Section WithMap.
   Definition run_query (rs : rule_set) n : ST _ :=
     match nth_error rs.(compiled_rules) n with
     | Some r =>
-        @! let db_tries <- build_tries rs in
+        @! let db_tries <- build_tries 0 rs in
           (*TODO: frontier_n a hack*)
           let tries : ne_list _ := ne_map (trie_of_clause' r.(query_vars) db_tries)
                                      r.(query_clause_ptrs) in
@@ -875,7 +891,7 @@ Section WithMap.
   Definition run_query' (rs : rule_set) n : ST _ :=
     match nth_error rs.(compiled_rules) n with
     | Some r =>
-        @! let db_tries <- build_tries rs in
+        @! let db_tries <- build_tries 0 rs in
           (*TODO: frontier_n a hack*)
           let tries : ne_list _ := ne_map (trie_of_clause' r.(query_vars) db_tries)
                                      r.(query_clause_ptrs) in
@@ -960,19 +976,19 @@ Arguments rebuild {idx}%_type_scope {Eqb_idx} {symbol}%_type_scope
   fuel%_nat_scope _.
 
 
-Arguments saturate_until' {idx}%_type_scope {Eqb_idx} idx_succ%_function_scope 
-  idx_zero {symbol}%_type_scope {symbol_map}%_function_scope {symbol_map_plus}
+Arguments saturate_until' {idx}%_type_scope {Eqb_idx} idx_succ%_function_scope
+  idx_zero idx_leb%_function_scope {symbol}%_type_scope {symbol_map}%_function_scope {symbol_map_plus}
   {idx_map}%_function_scope {idx_map_plus} {idx_trie}%_function_scope
   {analysis_result}%_type_scope {H}
-  spaced_list_intersect%_function_scope 
-  _ rs P fuel%_nat_scope.
+  spaced_list_intersect%_function_scope
+  _ window%_nat_scope rs P fuel%_nat_scope.
 
-Arguments saturate_until {idx}%_type_scope {Eqb_idx} idx_succ%_function_scope 
-  idx_zero {symbol}%_type_scope {symbol_map}%_function_scope {symbol_map_plus}
+Arguments saturate_until {idx}%_type_scope {Eqb_idx} idx_succ%_function_scope
+  idx_zero idx_leb%_function_scope {symbol}%_type_scope {symbol_map}%_function_scope {symbol_map_plus}
   {idx_map}%_function_scope {idx_map_plus} {idx_trie}%_function_scope
   {analysis_result}%_type_scope {H}
   spaced_list_intersect%_function_scope rebuild_fuel
-  rs P fuel%_nat_scope _.
+  window%_nat_scope rs P fuel%_nat_scope _.
 
 Arguments are_unified {idx}%_type_scope {Eqb_idx} {symbol}%_type_scope
   {symbol_map idx_map idx_trie}%_function_scope

--- a/src/Utils/EGraph/Defs.v
+++ b/src/Utils/EGraph/Defs.v
@@ -16,6 +16,15 @@ Notation ne_list A := (A * list A)%type.
 Definition ne_map {A B} (f : A -> B) (l : ne_list A) : ne_list B :=
   (f (fst l), map f (snd l)).
 
+(* Indexed map over a non-empty list: the head gets position 0 and the
+   tail elements get positions 1,2,.... Used for the proper semi-naive
+   (OLD/NEW/TOTAL) frontier selection, where each clause's *position* in
+   query_clause_ptrs (not its per-symbol hash-cons id) drives the choice. *)
+Definition ne_map_idx {A B} (f : nat -> A -> B) (l : ne_list A) : ne_list B :=
+  (f 0 (fst l),
+    List.map (fun p => f (fst p) (snd p))
+      (List.combine (List.seq 1 (List.length (snd l))) (snd l))).
+
 (*TODO: move*)
 #[export] Instance dlist_default : WithDefault dlist := dnil.
 
@@ -508,13 +517,20 @@ Section WithMap.
   (* build all the tries for a given symbol at once
      TODO: likely bug returning leaf in some cases
    *)
+  (* Per clause id, a triple (full, new, old):
+       full = every matching assignment;
+       new  = matched via an entry with epoch = current_epoch (the delta);
+       old  = matched via an entry with epoch <> current_epoch.
+     Since each (symbol,args) has exactly one entry/epoch, full partitions
+     into new (epoch = current) and old (epoch <> current).  The proper
+     semi-naive frontier selection picks one of the three by clause position. *)
   Definition build_tries_for_symbol
     (current_epoch : idx)
     (q_clauses : idx_map (list nat * nat))
     (tbl : idx_trie db_entry)
-    : idx_map (idx_trie unit * idx_trie unit) (* full * frontier *)
-    :=    
-    let upd_trie_pair (args : list idx) '(Build_db_entry epoch v a) '(full, frontier) clause :=
+    : idx_map (idx_trie unit * idx_trie unit * idx_trie unit) (* full * new * old *)
+    :=
+    let upd_trie_pair (args : list idx) '(Build_db_entry epoch v a) '(full, new, old) clause :=
       match match_clause clause args v with
       | Some assignment =>
           (* TODO: possible issue w/ tuple ordering
@@ -522,15 +538,16 @@ Section WithMap.
            *)
           let full' : idx_trie unit := map.put full assignment tt in
           if eqb epoch current_epoch
-          then (full', map.put frontier assignment tt)
-          else (full', frontier)
-      | None => (full, frontier)
-      end          
-    in  
+          then (full', map.put new assignment tt, old)
+          else (full', new, map.put old assignment tt)
+      | None => (full, new, old)
+      end
+    in
     map.fold (fun tries args vp => map_intersect (upd_trie_pair args vp) tries q_clauses)
-      (map_map (fun _ => (map.empty, map.empty : idx_trie unit)) q_clauses) tbl.
+      (map_map (fun _ => (map.empty, map.empty, map.empty : idx_trie unit)) q_clauses) tbl.
 
-  Definition build_tries (q : rule_set) : ST (symbol_map (idx_map (idx_trie unit * idx_trie unit))) :=
+  Definition build_tries (q : rule_set)
+    : ST (symbol_map (idx_map (idx_trie unit * idx_trie unit * idx_trie unit))) :=
     fun i => (map_intersect (build_tries_for_symbol i.(epoch)) q.(query_clauses) i.(db), i).
 
   Context (spaced_list_intersect
@@ -557,23 +574,51 @@ Section WithMap.
 
   Definition trie_of_clause
     (query_vars : list idx)
-    (* each trie pair is (total, frontier) *)
-    (db_tries : symbol_map (idx_map (idx_trie unit * idx_trie unit)))
+    (* each trie triple is (total, new, old) *)
+    (db_tries : symbol_map (idx_map (idx_trie unit * idx_trie unit * idx_trie unit)))
     (frontier_n : idx)
     '(Build_erule_query_ptr f n clause_vars) : idx_trie unit * list bool :=
     let flags := variable_flags query_vars clause_vars in
     (* If f is not in db_tries, it means the DB contains no matching nodes *)
     match map.get db_tries f with
     | Some trie_list =>
-        let (total,frontier) := unwrap_with_default (map.get trie_list n) in
-        let inner_trie := if eqb (n : idx) frontier_n then frontier else total in
+        let '(total, new, old) := unwrap_with_default (map.get trie_list n) in
+        let inner_trie := if eqb (n : idx) frontier_n then new else total in
+        (inner_trie, flags)
+    | None => (map.empty, flags)
+    end.
+
+  (* Proper semi-naive clause selection: each clause is tagged with its
+     POSITION in the query (not its per-symbol hash-cons id n).  Given the
+     frontier position [frontier_pos], a clause at position [pos] picks
+       old  (pos < frontier_pos),
+       new  (pos = frontier_pos),
+       full (pos > frontier_pos).
+     This realizes  OLD_0 .. OLD_{i-1} /\ NEW_i /\ TOTAL_{i+1} .. TOTAL_{k-1},
+     so every new match is generated exactly once (at i = min new-clause). *)
+  Definition trie_of_clause_sn
+    (query_vars : list idx)
+    (db_tries : symbol_map (idx_map (idx_trie unit * idx_trie unit * idx_trie unit)))
+    (frontier_pos : nat)
+    (pos : nat)
+    '(Build_erule_query_ptr f n clause_vars) : idx_trie unit * list bool :=
+    let flags := variable_flags query_vars clause_vars in
+    match map.get db_tries f with
+    | Some trie_list =>
+        let '(full, new, old) := unwrap_with_default (map.get trie_list n) in
+        let inner_trie :=
+          match Nat.compare pos frontier_pos with
+          | Lt => old
+          | Eq => new
+          | Gt => full
+          end in
         (inner_trie, flags)
     | None => (map.empty, flags)
     end.
   
   Definition process_erule'
-    (* each trie pair is (total, frontier) *)
-    (db_tries : symbol_map (idx_map (idx_trie unit * idx_trie unit)))
+    (* each trie triple is (total, new, old) *)
+    (db_tries : symbol_map (idx_map (idx_trie unit * idx_trie unit * idx_trie unit)))
     (r : erule) (frontier_n : idx) : ST unit :=
     let tries : ne_list _ :=
       ne_map (trie_of_clause r.(query_vars) db_tries frontier_n)
@@ -583,11 +628,25 @@ Section WithMap.
 
   (* The match keys for a single frontier choice (no writes). *)
   Definition erule_frontier_keys
-    (db_tries : symbol_map (idx_map (idx_trie unit * idx_trie unit)))
+    (db_tries : symbol_map (idx_map (idx_trie unit * idx_trie unit * idx_trie unit)))
     (r : erule) (frontier_n : idx) : list (list idx) :=
     intersection_keys
       (ne_map (trie_of_clause r.(query_vars) db_tries frontier_n)
          r.(query_clause_ptrs)).
+
+  (* One frontier position of the proper semi-naive scan: intersect the
+     position-indexed tries (OLD prefix / NEW pivot / TOTAL suffix) and
+     exec_write each resulting key.  No dedup trie: by min-index, each new
+     match appears in exactly one frontier position. *)
+  Definition process_erule'_sn
+    (db_tries : symbol_map (idx_map (idx_trie unit * idx_trie unit * idx_trie unit)))
+    (r : erule) (frontier_pos : nat) : ST unit :=
+    let tries : ne_list _ :=
+      ne_map_idx (fun pos ptr =>
+                    trie_of_clause_sn r.(query_vars) db_tries frontier_pos pos ptr)
+        r.(query_clause_ptrs) in
+    let assignments : list _ := intersection_keys tries in
+    list_Miter (M:=ST) (exec_write r) assignments.
 
   (*TODO: avoid using this*)
   Fixpoint idx_of_nat n :=
@@ -596,22 +655,13 @@ Section WithMap.
     | S n => idx_succ (idx_of_nat n)
     end.
 
-  (* The semi-naive frontier loop double-counts: a match with k new clauses is
-     found once per frontier choice that lands on a new clause (it uses the
-     TOTAL trie for every non-frontier clause).  Since [exec_write] is
-     idempotent on a repeated assignment (it only re-allocates garbage idxs that
-     are immediately unioned away), we aggregate the keys from every frontier
-     choice into a single [idx_trie] (whose keys are unique [list idx]
-     assignments) and [exec_write] each exactly once. *)
+  (* Proper semi-naive evaluation: scan one frontier position per clause.
+     Position i intersects OLD_0..OLD_{i-1} /\ NEW_i /\ TOTAL_{i+1}.. .  By the
+     min-index argument every new match is produced in exactly one position, so
+     no post-hoc dedup trie is needed — just exec_write each key per position. *)
   Definition process_erule db_tries r : ST unit :=
     let nclauses := List.length (uncurry cons r.(query_clause_ptrs)) in
-    let seen : idx_trie unit :=
-      List.fold_left
-        (fun acc n =>
-           List.fold_left (fun acc' k => map.put acc' k tt)
-             (erule_frontier_keys db_tries r (idx_of_nat n)) acc)
-        (seq 0 nclauses) map.empty in
-    list_Miter (M:=ST) (exec_write r) (map.keys seen).
+    list_Miter (M:=ST) (process_erule'_sn db_tries r) (seq 0 nclauses).
 
   (* TODO: return the new epoch?  *)
   Definition increment_epoch : ST unit :=
@@ -791,14 +841,14 @@ Section WithMap.
   
   Definition trie_of_clause'
     (query_vars : list idx)
-    (* each trie pair is (total, frontier) *)
-    (db_tries : symbol_map (idx_map (idx_trie unit * idx_trie unit)))
+    (* each trie triple is (total, new, old) *)
+    (db_tries : symbol_map (idx_map (idx_trie unit * idx_trie unit * idx_trie unit)))
     '(Build_erule_query_ptr f n clause_vars) : idx_trie unit * list bool :=
     let flags := variable_flags query_vars clause_vars in
     match map.get db_tries f with
     | Some trie_list =>
         (* never use the frontier*)
-        let (total,_) := unwrap_with_default (map.get trie_list n) in
+        let '(total, _, _) := unwrap_with_default (map.get trie_list n) in
         let flags := variable_flags query_vars clause_vars in
         (total, flags)
     | None => (map.empty, flags)

--- a/src/Utils/EGraph/Defs.v
+++ b/src/Utils/EGraph/Defs.v
@@ -581,17 +581,37 @@ Section WithMap.
     let assignments : list _ := (intersection_keys tries) in
     list_Miter (M:=ST) (exec_write r) assignments.
 
+  (* The match keys for a single frontier choice (no writes). *)
+  Definition erule_frontier_keys
+    (db_tries : symbol_map (idx_map (idx_trie unit * idx_trie unit)))
+    (r : erule) (frontier_n : idx) : list (list idx) :=
+    intersection_keys
+      (ne_map (trie_of_clause r.(query_vars) db_tries frontier_n)
+         r.(query_clause_ptrs)).
+
   (*TODO: avoid using this*)
   Fixpoint idx_of_nat n :=
     match n with
     | 0 => idx_zero
     | S n => idx_succ (idx_of_nat n)
     end.
-  
+
+  (* The semi-naive frontier loop double-counts: a match with k new clauses is
+     found once per frontier choice that lands on a new clause (it uses the
+     TOTAL trie for every non-frontier clause).  Since [exec_write] is
+     idempotent on a repeated assignment (it only re-allocates garbage idxs that
+     are immediately unioned away), we aggregate the keys from every frontier
+     choice into a single [idx_trie] (whose keys are unique [list idx]
+     assignments) and [exec_write] each exactly once. *)
   Definition process_erule db_tries r : ST unit :=
-    (* TODO: don't construct the list of nats/idxs, just iterate directly *)
-    list_Miter (fun n => process_erule' db_tries r (idx_of_nat n))
-      (seq 0 (List.length (uncurry cons r.(query_clause_ptrs)))).
+    let nclauses := List.length (uncurry cons r.(query_clause_ptrs)) in
+    let seen : idx_trie unit :=
+      List.fold_left
+        (fun acc n =>
+           List.fold_left (fun acc' k => map.put acc' k tt)
+             (erule_frontier_keys db_tries r (idx_of_nat n)) acc)
+        (seq 0 nclauses) map.empty in
+    list_Miter (M:=ST) (exec_write r) (map.keys seen).
 
   (* TODO: return the new epoch?  *)
   Definition increment_epoch : ST unit :=

--- a/src/Utils/EGraph/QcAlignment.v
+++ b/src/Utils/EGraph/QcAlignment.v
@@ -59,29 +59,29 @@ Qed.
    fpt_depth equal to the length of the clause variable list.
    ============================================================================ *)
 
-Lemma trie_of_clause_depth
+Lemma trie_of_clause_sn_depth
   (rf : nat) (rules : list (Semantics.sequent positive positive))
   (er : Defs.erule positive positive)
   (Hin : In er (Defs.compiled_rules positive positive TrieMap.trie_map TrieMap.trie_map (brs rf rules)))
   (e : Defs.instance positive positive TrieMap.trie_map TrieMap.trie_map
          (fun A => @FullPosTrie.full_pos_trie_map A) (option positive))
-  (frontier_n f n : positive) (cvars : list positive)
+  (frontier_pos pos : nat) (f n : positive) (cvars : list positive)
   (Hptr : In (Defs.Build_erule_query_ptr positive positive f n cvars)
              (uncurry cons (Defs.query_clause_ptrs positive positive er))) :
   fpt_depth
-    (fst (@Defs.trie_of_clause positive positive_Eqb positive
+    (fst (@Defs.trie_of_clause_sn positive positive_Eqb positive
             TrieMap.trie_map TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A)
             (Defs.query_vars positive positive er)
             (fst (@Defs.build_tries positive positive_Eqb positive TrieMap.trie_map
                     TrieMap.ptree_map_plus TrieMap.trie_map TrieMap.ptree_map_plus
                     (fun A => @FullPosTrie.full_pos_trie_map A)
                     (option positive) (brs rf rules) e))
-            frontier_n
+            frontier_pos pos
             (Defs.Build_erule_query_ptr positive positive f n cvars)))
     (length cvars).
 Proof.
   cbn [Defs.build_tries fst].
-  unfold Defs.trie_of_clause.
+  unfold Defs.trie_of_clause_sn.
   set (DBT := map_intersect
                 (Defs.build_tries_for_symbol positive positive_Eqb TrieMap.trie_map
                    TrieMap.ptree_map_plus (fun A => @FullPosTrie.full_pos_trie_map A)
@@ -98,7 +98,7 @@ Proof.
   rewrite (@intersect_spec positive TrieMap.trie_map TrieMap.ptree_map_plus TrieMap.ptree_map_plus_ok
     (TrieMap.trie_map (list nat * nat))
     (@FullPosTrie.full_pos_trie_map (Defs.db_entry positive (option positive)))
-    (TrieMap.trie_map (@FullPosTrie.full_pos_trie_map unit * @FullPosTrie.full_pos_trie_map unit))
+    (TrieMap.trie_map (@FullPosTrie.full_pos_trie_map unit * @FullPosTrie.full_pos_trie_map unit * @FullPosTrie.full_pos_trie_map unit))
     (Defs.build_tries_for_symbol positive positive_Eqb TrieMap.trie_map
        TrieMap.ptree_map_plus (fun A => @FullPosTrie.full_pos_trie_map A)
        (option positive) (Defs.epoch e))
@@ -115,13 +115,13 @@ Proof.
       TrieMap.trie_map TrieMap.ptree_map_plus TrieMap.ptree_map_plus_ok
       (option positive)
       (Defs.epoch e) q_f tbl_f n (cargs, cv) Hgetn)
-      as (ft & Hgetft & Hdf & Hds).
+      as (ft & Hgetft & Hdf & Hdn & Hdo).
     rewrite <- Heq_tl.
     unfold unwrap_with_default.
     rewrite Hgetft.
-    destruct ft as [total frontier]. cbn [fst snd] in Hdf, Hds.
+    destruct ft as [[total new] old]. cbn [fst snd] in Hdf, Hdn, Hdo.
     rewrite <- Hclen.
-    destruct (eqb n frontier_n); cbn [fst]; assumption. }
+    destruct (Nat.compare pos frontier_pos); cbn [fst]; assumption. }
   { (* None: contradiction *)
     unfold Defs.db_map in Hdb.
     rewrite Hdb in Hdbt.
@@ -228,6 +228,73 @@ Proof.
 Qed.
 
 (* ============================================================================
+   ne_map_idx membership helpers (proper semi-naive position recovery).
+
+   [ne_map_idx f (h,tl)] = (f 0 h, map (fun pr => f (fst pr) (snd pr))
+                                       (combine (seq 1 (length tl)) tl)).
+   To migrate the (ne_map -> ne_map_idx) intersection chain we need to (a)
+   recover, for any element of the produced list, the underlying clause ptr
+   together with its position, and (b) given a clause ptr in the tail, exhibit
+   its position so the corresponding tail bool list can be witnessed.
+   ============================================================================ *)
+
+(* If [a] occurs in [l], it occurs (paired with some position) in
+   [combine (seq base (length l)) l]. *)
+Lemma in_combine_seq_r_base {A} (l : list A) (a : A) (base : nat) :
+  In a l -> exists pos, In (pos, a) (combine (seq base (length l)) l).
+Proof.
+  revert base. induction l as [|x l' IH]; intros base Hin; [inversion Hin|].
+  cbn [length seq combine]. destruct Hin as [<-|Hin].
+  - exists base. left. reflexivity.
+  - destruct (IH (S base) Hin) as [pos Hpos]. exists pos. right. exact Hpos.
+Qed.
+
+(* Every element of [uncurry cons (ne_map_idx f l)] is [f pos a] for some
+   position [pos] and some [a] in [uncurry cons l]. *)
+Lemma in_ne_map_idx_uncurry_inv {A B} (f : nat -> A -> B) (l : ne_list A) (p : B) :
+  In p (uncurry cons (ne_map_idx f l)) ->
+  exists pos a, p = f pos a /\ In a (uncurry cons l).
+Proof.
+  destruct l as [h tl]. unfold ne_map_idx. cbn [uncurry fst snd].
+  intros [Hh | Ht].
+  - exists 0, h. split; [exact (eq_sym Hh) | left; reflexivity].
+  - apply in_map_iff in Ht. destruct Ht as [[pos a] [Heq Hpr]].
+    exists pos, a. split; [exact (eq_sym Heq)|].
+    right. exact (in_combine_r _ _ _ _ Hpr).
+Qed.
+
+(* Membership in the tail lifts to membership in [uncurry cons]. *)
+Lemma in_snd_uncurry_cons {A} (l : A * list A) (a : A) :
+  In a (snd l) -> In a (uncurry cons l).
+Proof. destruct l as [h tl]. cbn [uncurry fst snd]. intro. right. assumption. Qed.
+
+(* If [tl[k] = a] then [(base+k, a)] occurs in [combine (seq base (length tl)) tl]. *)
+Lemma nth_error_combine_seq {A} (tl : list A) (k : nat) (a : A) (base : nat) :
+  nth_error tl k = Some a -> In (base + k, a) (combine (seq base (length tl)) tl).
+Proof.
+  revert k base. induction tl as [|x tl' IH]; intros k base Hk; [destruct k; discriminate|].
+  cbn [length seq combine]. destruct k as [|k'].
+  - cbn [nth_error] in Hk. injection Hk as <-. left. f_equal. Lia.lia.
+  - cbn [nth_error] in Hk. right.
+    replace (base + S k') with (S base + k') by Lia.lia. apply IH. exact Hk.
+Qed.
+
+(* The element at position [pos] of [uncurry cons l] is either the head (pos 0)
+   or appears (paired with [pos]) in [combine (seq 1 (length (snd l))) (snd l)] —
+   i.e. exactly where [ne_map_idx] places it. *)
+Lemma nth_error_ne_map_idx_combine {A} (l : ne_list A) (pos : nat) (a : A) :
+  nth_error (uncurry cons l) pos = Some a ->
+  (pos = 0 /\ a = fst l) \/ In (pos, a) (combine (seq 1 (length (snd l))) (snd l)).
+Proof.
+  destruct l as [h tl]. cbn [uncurry fst snd].
+  destruct pos as [|k]; cbn [nth_error].
+  - intro Hk. injection Hk as <-. left. split; reflexivity.
+  - intro Hk. right.
+    pose proof (nth_error_combine_seq tl k a 1 Hk) as Hc.
+    cbn [Nat.add] in Hc. exact Hc.
+Qed.
+
+(* ============================================================================
    UNIT B2 assembly: combined_bools of the intersection tries = repeat true N
    ============================================================================ *)
 
@@ -237,15 +304,15 @@ Lemma intersection_inputs_combined_bools
   (Hin : In er (Defs.compiled_rules positive positive TrieMap.trie_map TrieMap.trie_map (brs rf rules)))
   (e : Defs.instance positive positive TrieMap.trie_map TrieMap.trie_map
          (fun A => @FullPosTrie.full_pos_trie_map A) (option positive))
-  (frontier_n : positive) :
+  (frontier_pos : nat) :
   let qv := Defs.query_vars positive positive er in
   let DBT := fst (@Defs.build_tries positive positive_Eqb positive TrieMap.trie_map
                     TrieMap.ptree_map_plus TrieMap.trie_map TrieMap.ptree_map_plus
                     (fun A => @FullPosTrie.full_pos_trie_map A)
                     (option positive) (brs rf rules) e) in
-  let toc := @Defs.trie_of_clause positive positive_Eqb positive
-                TrieMap.trie_map TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A) qv DBT frontier_n in
-  let tries_ne := ne_map toc (Defs.query_clause_ptrs positive positive er) in
+  let toc := fun pos ptr => @Defs.trie_of_clause_sn positive positive_Eqb positive
+                TrieMap.trie_map TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A) qv DBT frontier_pos pos ptr in
+  let tries_ne := ne_map_idx toc (Defs.query_clause_ptrs positive positive er) in
   let cvt := fun (q : @FullPosTrie.full_pos_trie_map unit * list bool) =>
                (FullPosTrieConv.fpt_to_pt (fst q), snd q) in
   @PosListMapIntersectSpec.combined_bools unit
@@ -253,31 +320,33 @@ Lemma intersection_inputs_combined_bools
   = repeat true (length qv).
 Proof.
   intros qv DBT toc tries_ne cvt.
-  (* unfold combined_bools and ne_map *)
+  (* unfold combined_bools and ne_map_idx *)
   unfold PosListMapIntersectSpec.combined_bools.
   cbn [fst snd].
-  unfold tries_ne, ne_map. cbn [fst snd].
+  unfold tries_ne, ne_map_idx. cbn [fst snd].
   (* Rewrite the fold to use t instead of snd p *)
   rewrite (fold_left_map2_orb_snd_eq (@snd pos_trie (list bool))
-    (map cvt (map toc (snd (query_clause_ptrs positive positive er))))).
+    (map cvt (map (fun pr => toc (fst pr) (snd pr))
+                  (combine (seq 1 (length (snd (query_clause_ptrs positive positive er))))
+                           (snd (query_clause_ptrs positive positive er)))))).
   (* Step 2: apply fold_left_map2_orb_all_true *)
   apply fold_left_map2_orb_all_true with (L := length qv).
   { (* length head = L *)
     destruct (fst (query_clause_ptrs positive positive er)) as [f_h n_h cvars_h].
-    cbn [Defs.trie_of_clause toc snd cvt].
+    cbn [Defs.trie_of_clause_sn toc snd cvt].
     destruct (map.get DBT f_h) as [tl|].
-    - destruct (unwrap_with_default (map.get tl n_h)) as [tot fr].
-      destruct (eqb n_h frontier_n); cbn [snd]; apply variable_flags_length.
+    - destruct (unwrap_with_default (map.get tl n_h)) as [[tot new] old].
+      destruct (Nat.compare 0 frontier_pos); cbn [snd]; apply variable_flags_length.
     - cbn [snd]. apply variable_flags_length. }
   { (* lengths of tails = L *)
     intros t0 Hin_t0.
     apply in_map_iff in Hin_t0. destruct Hin_t0 as [[trie0 bl0] [Heq0 Hin0]].
     apply in_map_iff in Hin0. destruct Hin0 as [[trie1 bl1] [Heq1 Hin1]].
-    apply in_map_iff in Hin1. destruct Hin1 as [[f2 n2 cvars2] [Heq2 _]].
-    cbn [Defs.trie_of_clause toc] in Heq2.
+    apply in_map_iff in Hin1. destruct Hin1 as [[pos2 [f2 n2 cvars2]] [Heq2 _]].
+    cbn [Defs.trie_of_clause_sn toc fst snd] in Heq2.
     destruct (map.get DBT f2) as [tl2|].
-    - destruct (unwrap_with_default (map.get tl2 n2)) as [tot2 fr2].
-      destruct (eqb n2 frontier_n); cbn [snd] in Heq2;
+    - destruct (unwrap_with_default (map.get tl2 n2)) as [[tot2 new2] old2].
+      destruct (Nat.compare pos2 frontier_pos); cbn [snd] in Heq2;
         injection Heq2 as _ <-;
         cbn [snd cvt] in Heq1; injection Heq1 as _ <-;
         cbn [snd] in Heq0; rewrite <- Heq0; apply variable_flags_length.
@@ -358,11 +427,11 @@ Proof.
     { (* head_ptr = ptr_i *)
       left.
       rewrite Hhead.
-      cbn [Defs.trie_of_clause toc snd cvt
+      cbn [Defs.trie_of_clause_sn toc snd cvt
            Defs.query_ptr_symbol Defs.query_ptr_ptr Defs.query_ptr_args].
       destruct (map.get DBT f_i) as [tl|].
-      { destruct (unwrap_with_default (map.get tl n_i)) as [tot fr].
-        destruct (eqb n_i frontier_n); cbn [snd].
+      { destruct (unwrap_with_default (map.get tl n_i)) as [[tot new] old].
+        destruct (Nat.compare 0 frontier_pos); cbn [snd].
         all: (replace qv with qvars in * by reflexivity;
               rewrite HcvarsEq';
               rewrite (@BuildTriesDepth.variable_flags_eq_map_filter
@@ -375,24 +444,27 @@ Proof.
         erewrite (nth_map_lt Pf qvars j false positive_default Hj). exact Hpf_j. } }
     { (* ptr_i ∈ rest_ptrs *)
       right.
+      destruct (in_combine_seq_r_base rest_ptrs
+                  {| Defs.query_ptr_symbol := f_i; Defs.query_ptr_ptr := n_i;
+                     Defs.query_ptr_args := cvars_i |} 1 Hrest) as [pos Hpos].
       refine (ex_intro _
-        (snd (cvt (toc {| Defs.query_ptr_symbol := f_i; Defs.query_ptr_ptr := n_i;
+        (snd (cvt (toc pos {| Defs.query_ptr_symbol := f_i; Defs.query_ptr_ptr := n_i;
                           Defs.query_ptr_args := cvars_i |}))) _).
       split.
       { apply in_map_iff.
-        refine (ex_intro _ (cvt (toc {| Defs.query_ptr_symbol := f_i; Defs.query_ptr_ptr := n_i;
+        refine (ex_intro _ (cvt (toc pos {| Defs.query_ptr_symbol := f_i; Defs.query_ptr_ptr := n_i;
                                         Defs.query_ptr_args := cvars_i |})) (conj eq_refl _)).
         apply in_map_iff.
-        refine (ex_intro _ (toc {| Defs.query_ptr_symbol := f_i; Defs.query_ptr_ptr := n_i;
+        refine (ex_intro _ (toc pos {| Defs.query_ptr_symbol := f_i; Defs.query_ptr_ptr := n_i;
                                    Defs.query_ptr_args := cvars_i |}) (conj eq_refl _)).
         apply in_map_iff.
-        exact (ex_intro _ {| Defs.query_ptr_symbol := f_i; Defs.query_ptr_ptr := n_i;
-                              Defs.query_ptr_args := cvars_i |} (conj eq_refl Hrest)). }
-      { cbn [Defs.trie_of_clause toc snd cvt
+        exact (ex_intro _ (pos, {| Defs.query_ptr_symbol := f_i; Defs.query_ptr_ptr := n_i;
+                              Defs.query_ptr_args := cvars_i |}) (conj eq_refl Hpos)). }
+      { cbn [Defs.trie_of_clause_sn toc snd cvt
              Defs.query_ptr_symbol Defs.query_ptr_ptr Defs.query_ptr_args].
         destruct (map.get DBT f_i) as [tl|].
-        { destruct (unwrap_with_default (map.get tl n_i)) as [tot fr].
-          destruct (eqb n_i frontier_n); cbn [snd].
+        { destruct (unwrap_with_default (map.get tl n_i)) as [[tot new] old].
+          destruct (Nat.compare pos frontier_pos); cbn [snd].
           all: (replace qv with qvars in * by reflexivity;
                 rewrite HcvarsEq';
                 rewrite (@BuildTriesDepth.variable_flags_eq_map_filter
@@ -457,107 +529,72 @@ Qed.
 
 (* Helper: S2 - each input trie has uniform depth = # true flags.
    Abstracted out because both H9 and H10 need it. *)
-Lemma trie_inputs_fpt_depth
+Lemma trie_inputs_fpt_depth_sn
   (rf : nat) (rules : list (Semantics.sequent positive positive))
   (er : Defs.erule positive positive)
   (Hin : In er (Defs.compiled_rules positive positive TrieMap.trie_map TrieMap.trie_map (brs rf rules)))
   (e : Defs.instance positive positive TrieMap.trie_map TrieMap.trie_map
          (fun A => @FullPosTrie.full_pos_trie_map A) (option positive))
-  (frontier_n : positive)
+  (frontier_pos : nat)
   (p : @FullPosTrie.full_pos_trie_map unit * list bool) :
-  In p (uncurry cons (ne_map
-    (@Defs.trie_of_clause positive positive_Eqb positive
+  In p (uncurry cons (ne_map_idx
+    (fun pos ptr => @Defs.trie_of_clause_sn positive positive_Eqb positive
        TrieMap.trie_map TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A)
        (Defs.query_vars positive positive er)
        (fst (@Defs.build_tries positive positive_Eqb positive TrieMap.trie_map
                TrieMap.ptree_map_plus TrieMap.trie_map TrieMap.ptree_map_plus
                (fun A => @FullPosTrie.full_pos_trie_map A)
                (option positive) (brs rf rules) e))
-       frontier_n)
+       frontier_pos pos ptr)
     (Defs.query_clause_ptrs positive positive er))) ->
   fpt_depth (fst p) (length (filter id (snd p))).
 Proof.
   intros Hp.
-  (* uncurry cons (ne_map f (a, l)) = f a :: map f l *)
-  cbn [uncurry ne_map fst snd] in Hp.
-  (* Hp : In p (toc (fst ptrs) :: map toc (snd ptrs)) *)
-  destruct Hp as [Hhead | Hrest].
-  - (* p = toc (fst ptrs) *)
-    subst p.
-    destruct (fst (Defs.query_clause_ptrs positive positive er)) as [f1 n1 cvars1] eqn:Hhead_ptr.
-    assert (Hptr_in : In (Defs.Build_erule_query_ptr positive positive f1 n1 cvars1)
-                         (uncurry cons (Defs.query_clause_ptrs positive positive er))).
-    { destruct (Defs.query_clause_ptrs positive positive er) as [hptr rptrs].
-      cbn [uncurry fst] in Hhead_ptr. rewrite <- Hhead_ptr.
-      left. reflexivity. }
-    pose proof (trie_of_clause_depth rf rules er Hin e frontier_n f1 n1 cvars1 Hptr_in) as Hd_fpt.
-    (* snd (toc frontier_n ptr) = variable_flags qv cvars1 *)
-    assert (Hsnd : snd (Defs.trie_of_clause positive positive_Eqb positive TrieMap.trie_map
-                          TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A)
-                          (Defs.query_vars positive positive er)
-                          (fst (@Defs.build_tries positive positive_Eqb positive TrieMap.trie_map
-                                  TrieMap.ptree_map_plus TrieMap.trie_map TrieMap.ptree_map_plus
-                                  (fun A => @FullPosTrie.full_pos_trie_map A)
-                                  (option positive) (brs rf rules) e))
-                          frontier_n
-                          (Defs.Build_erule_query_ptr positive positive f1 n1 cvars1))
-                  = Defs.variable_flags positive positive_Eqb (Defs.query_vars positive positive er) cvars1).
-    { unfold Defs.trie_of_clause. cbn [Defs.query_ptr_args snd].
-      destruct (map.get _ f1); [destruct (unwrap_with_default _) as [tot fr]; destruct (eqb n1 frontier_n)|]; reflexivity. }
-    rewrite Hsnd.
-    rewrite (flags_filter_id_len rf rules er Hin f1 n1 cvars1 Hptr_in).
-    exact Hd_fpt.
-  - (* p ∈ map toc (snd ptrs) *)
-    apply in_map_iff in Hrest.
-    destruct Hrest as [ptr [Heq Hptr_in]].
-    subst p.
-    destruct ptr as [f1 n1 cvars1].
-    assert (Hptr_uncurry : In (Defs.Build_erule_query_ptr positive positive f1 n1 cvars1)
-                              (uncurry cons (Defs.query_clause_ptrs positive positive er))).
-    { destruct (Defs.query_clause_ptrs positive positive er) as [hptr rptrs].
-      cbn [uncurry snd] in Hptr_in. right. exact Hptr_in. }
-    pose proof (trie_of_clause_depth rf rules er Hin e frontier_n f1 n1 cvars1 Hptr_uncurry) as Hd_fpt.
-    assert (Hsnd : snd (Defs.trie_of_clause positive positive_Eqb positive TrieMap.trie_map
-                          TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A)
-                          (Defs.query_vars positive positive er)
-                          (fst (@Defs.build_tries positive positive_Eqb positive TrieMap.trie_map
-                                  TrieMap.ptree_map_plus TrieMap.trie_map TrieMap.ptree_map_plus
-                                  (fun A => @FullPosTrie.full_pos_trie_map A)
-                                  (option positive) (brs rf rules) e))
-                          frontier_n
-                          (Defs.Build_erule_query_ptr positive positive f1 n1 cvars1))
-                  = Defs.variable_flags positive positive_Eqb (Defs.query_vars positive positive er) cvars1).
-    { unfold Defs.trie_of_clause. cbn [Defs.query_ptr_args snd].
-      destruct (map.get _ f1); [destruct (unwrap_with_default _) as [tot fr]; destruct (eqb n1 frontier_n)|]; reflexivity. }
-    rewrite Hsnd.
-    rewrite (flags_filter_id_len rf rules er Hin f1 n1 cvars1 Hptr_uncurry).
-    exact Hd_fpt.
+  destruct (in_ne_map_idx_uncurry_inv _ _ _ Hp) as [pos [ptr [Heqp Hptr]]].
+  destruct ptr as [f1 n1 cvars1].
+  subst p. cbn beta.
+  pose proof (trie_of_clause_sn_depth rf rules er Hin e frontier_pos pos f1 n1 cvars1 Hptr) as Hd_fpt.
+  assert (Hsnd : snd (@Defs.trie_of_clause_sn positive positive_Eqb positive TrieMap.trie_map
+                        TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A)
+                        (Defs.query_vars positive positive er)
+                        (fst (@Defs.build_tries positive positive_Eqb positive TrieMap.trie_map
+                                TrieMap.ptree_map_plus TrieMap.trie_map TrieMap.ptree_map_plus
+                                (fun A => @FullPosTrie.full_pos_trie_map A)
+                                (option positive) (brs rf rules) e))
+                        frontier_pos pos
+                        (Defs.Build_erule_query_ptr positive positive f1 n1 cvars1))
+                = Defs.variable_flags positive positive_Eqb (Defs.query_vars positive positive er) cvars1).
+  { unfold Defs.trie_of_clause_sn. cbn [Defs.query_ptr_args snd].
+    destruct (map.get _ f1); [destruct (unwrap_with_default _) as [[tot new] old]; destruct (Nat.compare pos frontier_pos)|]; reflexivity. }
+  rewrite Hsnd.
+  rewrite (flags_filter_id_len rf rules er Hin f1 n1 cvars1 Hptr).
+  exact Hd_fpt.
 Qed.
 
 (* Helper: S3 - wf_tries at any key of length N.
    Abstracted out because both H9 and H10 need it. *)
-Lemma trie_inputs_wf_at
+Lemma trie_inputs_wf_at_sn
   (rf : nat) (rules : list (Semantics.sequent positive positive))
   (er : Defs.erule positive positive)
   (Hin : In er (Defs.compiled_rules positive positive TrieMap.trie_map TrieMap.trie_map (brs rf rules)))
   (e : Defs.instance positive positive TrieMap.trie_map TrieMap.trie_map
          (fun A => @FullPosTrie.full_pos_trie_map A) (option positive))
-  (frontier_n : positive)
+  (frontier_pos : nat)
   (x : list positive)
   (Hlen : length x = length (Defs.query_vars positive positive er)) :
   let cvt := fun (q : @FullPosTrie.full_pos_trie_map unit * list bool) =>
                (FullPosTrieConv.fpt_to_pt (fst q), snd q) in
-  let toc := @Defs.trie_of_clause positive positive_Eqb positive
+  let toc := fun pos ptr => @Defs.trie_of_clause_sn positive positive_Eqb positive
                TrieMap.trie_map TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A)
                (Defs.query_vars positive positive er)
                (fst (@Defs.build_tries positive positive_Eqb positive TrieMap.trie_map
                        TrieMap.ptree_map_plus TrieMap.trie_map TrieMap.ptree_map_plus
                        (fun A => @FullPosTrie.full_pos_trie_map A)
                        (option positive) (brs rf rules) e))
-               frontier_n in
+               frontier_pos pos ptr in
   PosListMapIntersectSpec.wf_tries x
-    (cvt (fst (ne_map toc (Defs.query_clause_ptrs positive positive er))),
-     map cvt (snd (ne_map toc (Defs.query_clause_ptrs positive positive er)))).
+    (cvt (fst (ne_map_idx toc (Defs.query_clause_ptrs positive positive er))),
+     map cvt (snd (ne_map_idx toc (Defs.query_clause_ptrs positive positive er)))).
 Proof.
   intros cvt toc.
   set (qv := Defs.query_vars positive positive er) in toc, Hlen |- *.
@@ -565,69 +602,43 @@ Proof.
                     TrieMap.ptree_map_plus TrieMap.trie_map TrieMap.ptree_map_plus
                     (fun A => @FullPosTrie.full_pos_trie_map A)
                     (option positive) (brs rf rules) e)) in toc |- *.
-  pose proof (fun p Hp => trie_inputs_fpt_depth rf rules er Hin e frontier_n p Hp) as Hfd.
-  (* fold qv, DBT in Hfd *)
-  change (Defs.query_vars positive positive er) with qv in Hfd.
-  change (fst (@Defs.build_tries positive positive_Eqb positive TrieMap.trie_map
-                    TrieMap.ptree_map_plus TrieMap.trie_map TrieMap.ptree_map_plus
-                    (fun A => @FullPosTrie.full_pos_trie_map A)
-                    (option positive) (brs rf rules) e)) with DBT in Hfd.
   unfold PosListMapIntersectSpec.wf_tries.
-  (* Helper: for any ptr in query_clause_ptrs, wf_input x (cvt (toc ptr)) *)
-  assert (Hwf_ptr : forall ptr,
+  (* Helper: for any pos and any ptr in query_clause_ptrs, wf_input x (cvt (toc pos ptr)).
+     The (old/new/full) selection only changes the trie, not its depth or its bools,
+     so wf_input holds at every position. *)
+  assert (Hwf_elem : forall pos ptr,
     In ptr (uncurry cons (Defs.query_clause_ptrs positive positive er)) ->
-    PosListMapIntersectSpec.wf_input x (cvt (toc ptr))).
-  { intros [f0 n0 cvars0] Hptr0.
+    PosListMapIntersectSpec.wf_input x (cvt (toc pos ptr))).
+  { intros pos [f0 n0 cvars0] Hptr0.
     unfold PosListMapIntersectSpec.wf_input. cbn [toc cvt].
+    assert (Hsnd0 : snd (toc pos (Defs.Build_erule_query_ptr positive positive f0 n0 cvars0))
+                   = Defs.variable_flags positive positive_Eqb qv cvars0).
+    { unfold toc. unfold Defs.trie_of_clause_sn. cbn [Defs.query_ptr_args snd].
+      destruct (map.get DBT f0) as [tl0|].
+      - destruct (unwrap_with_default (map.get tl0 n0)) as [[tot new] old].
+        destruct (Nat.compare pos frontier_pos); reflexivity.
+      - reflexivity. }
     split.
-    + (* length (snd (cvt (toc ptr))) = length x *)
-      assert (Hsnd0 : snd (toc (Defs.Build_erule_query_ptr positive positive f0 n0 cvars0))
-                     = Defs.variable_flags positive positive_Eqb qv cvars0).
-      { unfold toc. unfold Defs.trie_of_clause. cbn [Defs.query_ptr_args snd].
-        destruct (map.get DBT f0) as [tl0|].
-        - destruct (unwrap_with_default (map.get tl0 n0)) as [tot fr].
-          destruct (eqb n0 frontier_n); reflexivity.
-        - reflexivity. }
+    + (* length (snd (cvt (toc pos ptr))) = length x *)
       cbn [cvt snd fst]. rewrite Hsnd0.
       rewrite @BuildTriesDepth.variable_flags_length. symmetry. exact Hlen.
     + (* depth *)
-      specialize (Hfd (toc (Defs.Build_erule_query_ptr positive positive f0 n0 cvars0))).
-      assert (Hp : In (toc (Defs.Build_erule_query_ptr positive positive f0 n0 cvars0))
-                      (uncurry cons (ne_map toc (Defs.query_clause_ptrs positive positive er)))).
-      { cbn [uncurry ne_map fst snd].
-        destruct (Defs.query_clause_ptrs positive positive er) as [hptr rptrs] eqn:Hptrs.
-        cbn [uncurry fst snd] in Hptr0.
-        destruct Hptr0 as [Hh | Hr].
-        - left. f_equal. exact Hh.
-        - right. apply in_map_iff.
-          exact (ex_intro _ (Defs.Build_erule_query_ptr positive positive f0 n0 cvars0)
-                           (conj eq_refl Hr)). }
-      specialize (Hfd Hp).
-      assert (Hsnd0 : snd (toc (Defs.Build_erule_query_ptr positive positive f0 n0 cvars0))
-                     = Defs.variable_flags positive positive_Eqb qv cvars0).
-      { unfold toc. unfold Defs.trie_of_clause. cbn [Defs.query_ptr_args snd].
-        destruct (map.get DBT f0) as [tl0|].
-        - destruct (unwrap_with_default (map.get tl0 n0)) as [tot fr].
-          destruct (eqb n0 frontier_n); reflexivity.
-        - reflexivity. }
-      rewrite Hsnd0 in Hfd.
-      unfold qv in Hfd.
-      rewrite (flags_filter_id_len rf rules er Hin f0 n0 cvars0 Hptr0) in Hfd.
-      (* Hfd : fpt_depth (fst (toc ptr)) (length cvars0) *)
+      pose proof (trie_of_clause_sn_depth rf rules er Hin e frontier_pos pos f0 n0 cvars0 Hptr0) as Hfd.
       cbn [cvt fst snd].
-      (* rewrite snd (toc ptr) = variable_flags ... in the GOAL to unify the lengths *)
       rewrite Hsnd0.
       unfold qv.
       rewrite (flags_filter_id_len rf rules er Hin f0 n0 cvars0 Hptr0).
-      set (t0 := fst (toc (Defs.Build_erule_query_ptr positive positive f0 n0 cvars0))).
+      set (t0 := fst (toc pos (Defs.Build_erule_query_ptr positive positive f0 n0 cvars0))).
+      unfold qv in Hfd.
       pose proof (FullPosTrieConv.fpt_to_pt_has_depth' t0 (length cvars0) Hfd) as Hdepth_pt.
       unfold depth in Hdepth_pt.
       destruct (FullPosTrieConv.fpt_to_pt t0) as [pt'|].
       * exact (@FullPosTrieConv.depth'_to_has_depth' unit _ pt' Hdepth_pt).
       * exact I. }
   split.
-  - (* head *)
-    apply Hwf_ptr.
+  - (* head: fst (ne_map_idx toc ptrs) = toc 0 (fst ptrs) *)
+    unfold ne_map_idx. cbn [fst].
+    apply Hwf_elem.
     destruct (Defs.query_clause_ptrs positive positive er) as [hptr rptrs].
     cbn [uncurry fst]. left. reflexivity.
   - (* tail *)
@@ -636,32 +647,32 @@ Proof.
     apply in_map_iff in Hcp.
     destruct Hcp as [p [Heq_cp Hp_in_rest]].
     subst cp.
+    unfold ne_map_idx in Hp_in_rest. cbn [snd] in Hp_in_rest.
     apply in_map_iff in Hp_in_rest.
-    destruct Hp_in_rest as [ptr [Heq_p Hptr_in]].
-    subst p.
-    apply Hwf_ptr.
-    destruct (Defs.query_clause_ptrs positive positive er) as [hptr rptrs] eqn:Hptrs.
-    cbn [uncurry snd] in Hptr_in. cbn [uncurry]. right. exact Hptr_in.
+    destruct Hp_in_rest as [[pos ptr] [Heq_p Hpr_in]].
+    subst p. cbn [fst snd].
+    apply Hwf_elem.
+    apply in_snd_uncurry_cons. exact (in_combine_r _ _ _ _ Hpr_in).
 Qed.
 
 (* Helper: the compat_intersect R has uniform depth N.
    Derived from pt_spaced_intersect_depth using wf_tries at repeat xH N and Hbools. *)
-Lemma trie_intersect_depth
+Lemma trie_intersect_depth_sn
   (rf : nat) (rules : list (Semantics.sequent positive positive))
   (er : Defs.erule positive positive)
   (Hin : In er (Defs.compiled_rules positive positive TrieMap.trie_map TrieMap.trie_map (brs rf rules)))
   (e : Defs.instance positive positive TrieMap.trie_map TrieMap.trie_map
          (fun A => @FullPosTrie.full_pos_trie_map A) (option positive))
-  (frontier_n : positive) :
+  (frontier_pos : nat) :
   let qv := Defs.query_vars positive positive er in
   let N := length qv in
   let DBT := fst (@Defs.build_tries positive positive_Eqb positive TrieMap.trie_map
                     TrieMap.ptree_map_plus TrieMap.trie_map TrieMap.ptree_map_plus
                     (fun A => @FullPosTrie.full_pos_trie_map A)
                     (option positive) (brs rf rules) e) in
-  let toc := @Defs.trie_of_clause positive positive_Eqb positive
-               TrieMap.trie_map TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A) qv DBT frontier_n in
-  let tries_ne := ne_map toc (Defs.query_clause_ptrs positive positive er) in
+  let toc := fun pos ptr => @Defs.trie_of_clause_sn positive positive_Eqb positive
+               TrieMap.trie_map TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A) qv DBT frontier_pos pos ptr in
+  let tries_ne := ne_map_idx toc (Defs.query_clause_ptrs positive positive er) in
   let cvt := fun (q : @FullPosTrie.full_pos_trie_map unit * list bool) =>
                (FullPosTrieConv.fpt_to_pt (fst q), snd q) in
   depth (compat_intersect merge_fn (cvt (fst tries_ne), map cvt (snd tries_ne))) N.
@@ -675,21 +686,21 @@ Proof.
                      TrieMap.ptree_map_plus TrieMap.trie_map TrieMap.ptree_map_plus
                      (fun A => @FullPosTrie.full_pos_trie_map A)
                      (option positive) (brs rf rules) e)).
-  set (toc_fn := @Defs.trie_of_clause positive positive_Eqb positive
-                    TrieMap.trie_map TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A) qv' DBT' frontier_n).
-  set (tries_ne' := ne_map toc_fn (Defs.query_clause_ptrs positive positive er)).
+  set (toc_fn := fun pos ptr => @Defs.trie_of_clause_sn positive positive_Eqb positive
+                    TrieMap.trie_map TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A) qv' DBT' frontier_pos pos ptr).
+  set (tries_ne' := ne_map_idx toc_fn (Defs.query_clause_ptrs positive positive er)).
   set (cvt' := fun (q : @FullPosTrie.full_pos_trie_map unit * list bool) =>
                  (FullPosTrieConv.fpt_to_pt (fst q), snd q)).
   (* The intro'd let-binders are definitionally equal to the set-bound ones *)
   change (depth (compat_intersect merge_fn (cvt' (fst tries_ne'), map cvt' (snd tries_ne'))) N').
   (* B2 via intersection_inputs_combined_bools *)
-  pose proof (intersection_inputs_combined_bools rf rules er Hin e frontier_n) as Hb.
+  pose proof (intersection_inputs_combined_bools rf rules er Hin e frontier_pos) as Hb.
   change (PosListMapIntersectSpec.combined_bools
             (cvt' (fst tries_ne'), map cvt' (snd tries_ne')) = repeat true N') in Hb.
   (* wf_tries at repeat xH N' *)
   assert (Hwf_dummy : PosListMapIntersectSpec.wf_tries (repeat xH N')
     (cvt' (fst tries_ne'), map cvt' (snd tries_ne'))).
-  { apply (trie_inputs_wf_at rf rules er Hin e frontier_n (repeat xH N')).
+  { apply (trie_inputs_wf_at_sn rf rules er Hin e frontier_pos (repeat xH N')).
     rewrite repeat_length. reflexivity. }
   (* pt_spaced_intersect_depth *)
   pose proof (@PosListMapIntersectSpec.pt_spaced_intersect_depth unit _
@@ -707,78 +718,69 @@ Qed.
 (* ============================================================================
    trie_join_H9: intersection key sigma has length = number of query vars.
    ============================================================================ *)
-Lemma trie_join_H9
+Lemma trie_join_H9_sn
   (rf : nat) (rules : list (Semantics.sequent positive positive))
   (er : Defs.erule positive positive)
   (Hin : In er (Defs.compiled_rules positive positive TrieMap.trie_map TrieMap.trie_map (brs rf rules)))
   (e : Defs.instance positive positive TrieMap.trie_map TrieMap.trie_map
          (fun A => @FullPosTrie.full_pos_trie_map A) (option positive)) :
-  forall frontier_n sigma,
+  forall frontier_pos sigma,
     In sigma (@Defs.intersection_keys positive (fun A => @FullPosTrie.full_pos_trie_map A)
                 (@FullPosTrieConv.fpt_spaced_intersect)
-                (ne_map (@Defs.trie_of_clause positive positive_Eqb positive
+                (ne_map_idx (fun pos ptr => @Defs.trie_of_clause_sn positive positive_Eqb positive
                            TrieMap.trie_map TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A)
                            (Defs.query_vars positive positive er)
                            (fst (@Defs.build_tries positive positive_Eqb positive TrieMap.trie_map
                                    TrieMap.ptree_map_plus TrieMap.trie_map TrieMap.ptree_map_plus
                                    (fun A => @FullPosTrie.full_pos_trie_map A)
                                    (option positive) (brs rf rules) e))
-                           frontier_n)
+                           frontier_pos pos ptr)
                          (Defs.query_clause_ptrs positive positive er))) ->
     length (Defs.query_vars positive positive er) = length sigma.
 Proof.
-  intros frontier_n sigma Hin_sig.
+  intros frontier_pos sigma Hin_sig.
   set (qv := Defs.query_vars positive positive er).
   set (N := length qv).
   set (DBT := fst (@Defs.build_tries positive positive_Eqb positive TrieMap.trie_map
                     TrieMap.ptree_map_plus TrieMap.trie_map TrieMap.ptree_map_plus
                     (fun A => @FullPosTrie.full_pos_trie_map A)
                     (option positive) (brs rf rules) e)).
-  set (toc_fn := @Defs.trie_of_clause positive positive_Eqb positive
-                   TrieMap.trie_map TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A) qv DBT).
-  set (tries_ne := ne_map (toc_fn frontier_n) (Defs.query_clause_ptrs positive positive er)).
+  set (toc_fn := fun pos ptr => @Defs.trie_of_clause_sn positive positive_Eqb positive
+                   TrieMap.trie_map TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A) qv DBT frontier_pos pos ptr).
+  set (tries_ne := ne_map_idx toc_fn (Defs.query_clause_ptrs positive positive er)).
   set (cvt := fun (q : @FullPosTrie.full_pos_trie_map unit * list bool) =>
                (FullPosTrieConv.fpt_to_pt (fst q), snd q)).
   (* Get depth *)
-  pose proof (trie_intersect_depth rf rules er Hin e frontier_n) as Hdepth.
+  pose proof (trie_intersect_depth_sn rf rules er Hin e frontier_pos) as Hdepth.
   change (depth (compat_intersect merge_fn (cvt (fst tries_ne), map cvt (snd tries_ne))) N)
     in Hdepth.
   (* Hbools: combined_bools = repeat true N *)
-  pose proof (intersection_inputs_combined_bools rf rules er Hin e frontier_n) as Hbools.
+  pose proof (intersection_inputs_combined_bools rf rules er Hin e frontier_pos) as Hbools.
   change (PosListMapIntersectSpec.combined_bools
             (cvt (fst tries_ne), map cvt (snd tries_ne)) = repeat true N) in Hbools.
   (* Hfd: each input has uniform fpt_depth = #true flags *)
-  pose proof (fun q Hq => trie_inputs_fpt_depth rf rules er Hin e frontier_n q Hq) as Hfd.
+  pose proof (fun q Hq => trie_inputs_fpt_depth_sn rf rules er Hin e frontier_pos q Hq) as Hfd.
   (* Hlenp: each input's bool list has length = N.
-     For each p = toc_fn frontier_n ptr, snd p = variable_flags qv cvars,
+     For each p = toc_fn pos ptr, snd p = variable_flags qv cvars,
      and length (variable_flags qv cvars) = length qv = N. *)
-  (* Helper to compute snd (toc_fn frontier_n ptr) = variable_flags qv cvars for any ptr *)
-  assert (Htoc_snd : forall f0 n0 cvars0,
-    snd (toc_fn frontier_n (Defs.Build_erule_query_ptr positive positive f0 n0 cvars0))
+  (* Helper to compute snd (toc_fn pos ptr) = variable_flags qv cvars for any pos, ptr *)
+  assert (Htoc_snd : forall pos f0 n0 cvars0,
+    snd (toc_fn pos (Defs.Build_erule_query_ptr positive positive f0 n0 cvars0))
     = Defs.variable_flags positive positive_Eqb qv cvars0).
-  { intros f0 n0 cvars0.
-    unfold toc_fn. unfold Defs.trie_of_clause. cbn [Defs.query_ptr_args snd].
+  { intros pos f0 n0 cvars0.
+    unfold toc_fn. unfold Defs.trie_of_clause_sn. cbn [Defs.query_ptr_args snd].
     destruct (map.get DBT f0) as [tl0|].
-    - destruct (unwrap_with_default (map.get tl0 n0)) as [tot fr].
-      destruct (eqb n0 frontier_n); reflexivity.
+    - destruct (unwrap_with_default (map.get tl0 n0)) as [[tot new] old].
+      destruct (Nat.compare pos frontier_pos); reflexivity.
     - reflexivity. }
   assert (Hlenp : forall p, In p (fst tries_ne :: snd tries_ne) -> length (snd p) = N).
   { intros p Hp.
-    (* Each element is toc_fn frontier_n ptr for some ptr *)
-    unfold tries_ne, ne_map in Hp. cbn [fst snd] in Hp.
-    destruct Hp as [Hhead | Hrest].
-    - (* p = toc_fn frontier_n (fst ptrs) *)
-      subst p.
-      destruct (fst (Defs.query_clause_ptrs positive positive er)) as [f0 n0 cvars0].
-      rewrite (Htoc_snd f0 n0 cvars0).
-      exact (@BuildTriesDepth.variable_flags_length positive positive_Eqb qv cvars0).
-    - (* p ∈ map (toc_fn frontier_n) (snd ptrs) *)
-      apply in_map_iff in Hrest.
-      destruct Hrest as [ptr [Heq Hptr_in]].
-      subst p.
-      destruct ptr as [f0 n0 cvars0].
-      rewrite (Htoc_snd f0 n0 cvars0).
-      exact (@BuildTriesDepth.variable_flags_length positive positive_Eqb qv cvars0). }
+    (* Each element is toc_fn pos ptr for some pos, ptr *)
+    change (In p (uncurry cons tries_ne)) in Hp.
+    destruct (in_ne_map_idx_uncurry_inv _ _ _ Hp) as [pos [[f0 n0 cvars0] [Heqp _]]].
+    subst p. cbn beta.
+    rewrite (Htoc_snd pos f0 n0 cvars0).
+    exact (@BuildTriesDepth.variable_flags_length positive positive_Eqb qv cvars0). }
   (* HnatD: fpt_spaced_intersect_native has uniform depth N *)
   pose proof (@FullPosTrieConv.fpt_spaced_intersect_native_depth unit _
                 merge_fn merge_comm_pf merge_assoc_pf
@@ -820,68 +822,68 @@ Qed.
    trie_join_H10: for each sigma in intersection keys and each clause ptr,
    the projected lookup in that ptr's trie hits Some tt.
    ============================================================================ *)
-Lemma trie_join_H10
+Lemma trie_join_H10_sn
   (rf : nat) (rules : list (Semantics.sequent positive positive))
   (er : Defs.erule positive positive)
   (Hin : In er (Defs.compiled_rules positive positive TrieMap.trie_map TrieMap.trie_map (brs rf rules)))
   (e : Defs.instance positive positive TrieMap.trie_map TrieMap.trie_map
          (fun A => @FullPosTrie.full_pos_trie_map A) (option positive)) :
-  forall frontier_n sigma,
+  forall frontier_pos sigma,
     In sigma (@Defs.intersection_keys positive (fun A => @FullPosTrie.full_pos_trie_map A)
                 (@FullPosTrieConv.fpt_spaced_intersect)
-                (ne_map (@Defs.trie_of_clause positive positive_Eqb positive
+                (ne_map_idx (fun pos ptr => @Defs.trie_of_clause_sn positive positive_Eqb positive
                            TrieMap.trie_map TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A)
                            (Defs.query_vars positive positive er)
                            (fst (@Defs.build_tries positive positive_Eqb positive TrieMap.trie_map
                                    TrieMap.ptree_map_plus TrieMap.trie_map TrieMap.ptree_map_plus
                                    (fun A => @FullPosTrie.full_pos_trie_map A)
                                    (option positive) (brs rf rules) e))
-                           frontier_n)
+                           frontier_pos pos ptr)
                          (Defs.query_clause_ptrs positive positive er))) ->
-    forall fsym nptr cvars,
-      In (Defs.Build_erule_query_ptr positive positive fsym nptr cvars)
-         (uncurry cons (Defs.query_clause_ptrs positive positive er)) ->
+    forall pos fsym nptr cvars,
+      nth_error (uncurry cons (Defs.query_clause_ptrs positive positive er)) pos
+        = Some (Defs.Build_erule_query_ptr positive positive fsym nptr cvars) ->
       @map.get (list positive) unit (@FullPosTrie.full_pos_trie_map unit)
-        (fst (@Defs.trie_of_clause positive positive_Eqb positive
+        (fst (@Defs.trie_of_clause_sn positive positive_Eqb positive
                 TrieMap.trie_map TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A)
                 (Defs.query_vars positive positive er)
                 (fst (@Defs.build_tries positive positive_Eqb positive TrieMap.trie_map
                         TrieMap.ptree_map_plus TrieMap.trie_map TrieMap.ptree_map_plus
                         (fun A => @FullPosTrie.full_pos_trie_map A)
                         (option positive) (brs rf rules) e))
-                frontier_n
+                frontier_pos pos
                 (Defs.Build_erule_query_ptr positive positive fsym nptr cvars)))
         (map fst (filter snd (combine sigma
            (Defs.variable_flags positive positive_Eqb
               (Defs.query_vars positive positive er) cvars))))
       = Some tt.
 Proof.
-  intros frontier_n sigma Hin_sig fsym nptr cvars Hptr.
+  intros frontier_pos sigma Hin_sig pos fsym nptr cvars Hnth.
   set (qv := Defs.query_vars positive positive er).
   set (N := length qv).
   set (DBT := fst (@Defs.build_tries positive positive_Eqb positive TrieMap.trie_map
                     TrieMap.ptree_map_plus TrieMap.trie_map TrieMap.ptree_map_plus
                     (fun A => @FullPosTrie.full_pos_trie_map A)
                     (option positive) (brs rf rules) e)).
-  set (toc_fn := @Defs.trie_of_clause positive positive_Eqb positive
-                   TrieMap.trie_map TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A) qv DBT).
-  set (tries_ne := ne_map (toc_fn frontier_n) (Defs.query_clause_ptrs positive positive er)).
+  set (toc_fn := fun pos ptr => @Defs.trie_of_clause_sn positive positive_Eqb positive
+                   TrieMap.trie_map TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A) qv DBT frontier_pos pos ptr).
+  set (tries_ne := ne_map_idx toc_fn (Defs.query_clause_ptrs positive positive er)).
   set (cvt := fun (q : @FullPosTrie.full_pos_trie_map unit * list bool) =>
                (FullPosTrieConv.fpt_to_pt (fst q), snd q)).
   set (R := compat_intersect merge_fn (cvt (fst tries_ne), map cvt (snd tries_ne))).
   (* H9: length sigma = N *)
-  pose proof (trie_join_H9 rf rules er Hin e frontier_n sigma Hin_sig) as Hlen.
+  pose proof (trie_join_H9_sn rf rules er Hin e frontier_pos sigma Hin_sig) as Hlen.
   (* Hlen : N = length sigma; so length sigma = N via symmetry *)
   (* Hbools *)
-  pose proof (intersection_inputs_combined_bools rf rules er Hin e frontier_n) as Hbools.
+  pose proof (intersection_inputs_combined_bools rf rules er Hin e frontier_pos) as Hbools.
   change (PosListMapIntersectSpec.combined_bools
             (cvt (fst tries_ne), map cvt (snd tries_ne)) = repeat true N) in Hbools.
   (* Hdepth *)
-  pose proof (trie_intersect_depth rf rules er Hin e frontier_n) as Hdepth.
+  pose proof (trie_intersect_depth_sn rf rules er Hin e frontier_pos) as Hdepth.
   change (depth (compat_intersect merge_fn (cvt (fst tries_ne), map cvt (snd tries_ne))) N)
     in Hdepth.
   (* wf_tries sigma *)
-  pose proof (trie_inputs_wf_at rf rules er Hin e frontier_n sigma (eq_sym Hlen)) as Hwf.
+  pose proof (trie_inputs_wf_at_sn rf rules er Hin e frontier_pos sigma (eq_sym Hlen)) as Hwf.
   change (PosListMapIntersectSpec.wf_tries sigma
             (cvt (fst tries_ne), map cvt (snd tries_ne))) in Hwf.
   (* Unfold intersection_keys in Hin_sig *)
@@ -889,31 +891,31 @@ Proof.
   change (In sigma (@map.keys (list positive) unit (@FullPosTrie.full_pos_trie_map unit)
              (FullPosTrieConv.fpt_spaced_intersect merge_fn tries_ne))) in Hin_sig.
   (* Hin_sig is already in native form; fpt_spaced_intersect_inputs_hit takes native keys *)
-  (* p = toc_fn frontier_n (Build_erule_query_ptr fsym nptr cvars) in tries::rest *)
-  set (p := toc_fn frontier_n (Defs.Build_erule_query_ptr positive positive fsym nptr cvars)).
+  (* p = toc_fn pos (Build_erule_query_ptr fsym nptr cvars) at position pos in tries::rest *)
+  set (p := toc_fn pos (Defs.Build_erule_query_ptr positive positive fsym nptr cvars)).
   assert (Hp_in : In p (fst tries_ne :: snd tries_ne)).
   { unfold p, tries_ne.
-    destruct (Defs.query_clause_ptrs positive positive er) as [hptr rptrs].
-    cbn [ne_map fst snd uncurry] in Hptr |- *.
-    destruct Hptr as [Hhead | Hrest_ptr].
-    - left. rewrite <- Hhead. reflexivity.
-    - right. apply in_map_iff.
-      exact (ex_intro _ (Defs.Build_erule_query_ptr positive positive fsym nptr cvars)
-                      (conj eq_refl Hrest_ptr)). }
+    destruct (nth_error_ne_map_idx_combine (Defs.query_clause_ptrs positive positive er) pos
+                (Defs.Build_erule_query_ptr positive positive fsym nptr cvars) Hnth)
+      as [[Hpos0 Hhead] | Hcomb].
+    - subst pos. unfold ne_map_idx. cbn [fst]. left. rewrite <- Hhead. reflexivity.
+    - right. unfold ne_map_idx. cbn [snd]. apply in_map_iff.
+      exact (ex_intro _ (pos, Defs.Build_erule_query_ptr positive positive fsym nptr cvars)
+                      (conj eq_refl Hcomb)). }
   (* Apply fpt_spaced_intersect_inputs_hit *)
   (* snd p = variable_flags qv cvars *)
   assert (Hsnd_p : snd p = Defs.variable_flags positive positive_Eqb qv cvars).
-  { unfold p. unfold toc_fn. unfold Defs.trie_of_clause. cbn [Defs.query_ptr_args snd].
+  { unfold p. unfold toc_fn. unfold Defs.trie_of_clause_sn. cbn [Defs.query_ptr_args snd].
     destruct (map.get DBT fsym) as [tl0|].
-    - destruct (unwrap_with_default (map.get tl0 nptr)) as [tot fr].
-      destruct (eqb nptr frontier_n); reflexivity.
+    - destruct (unwrap_with_default (map.get tl0 nptr)) as [[tot new] old].
+      destruct (Nat.compare pos frontier_pos); reflexivity.
     - reflexivity. }
   (* Apply fpt_spaced_intersect_inputs_hit *)
   pose proof (@FullPosTrieConv.fpt_spaced_intersect_inputs_hit unit _
                 merge_fn merge_comm_pf merge_assoc_pf
                 (fst tries_ne) (snd tries_ne) sigma N
                 Hin_sig (eq_sym Hlen) Hdepth Hbools Hwf
-                (fun q Hq => trie_inputs_fpt_depth rf rules er Hin e frontier_n q Hq)
+                (fun q Hq => trie_inputs_fpt_depth_sn rf rules er Hin e frontier_pos q Hq)
                 p Hp_in) as (v & Hv).
   (* Hv : fpt_get (fst p) (map fst (filter snd (combine sigma (snd p)))) = Some v *)
   (* Goal has variable_flags qv cvars. Rewrite <-Hsnd_p to get snd p in goal. *)

--- a/src/Utils/EGraph/QcAlignment.v
+++ b/src/Utils/EGraph/QcAlignment.v
@@ -35,7 +35,7 @@ Lemma compiled_rules_ptr_clen
 Proof.
   intros er Hin fsym nptr cvars Hptr.
   pose proof (@QueryOptSound.compiled_rules_ptr_shape
-    positive positive_Eqb BuildTriesDepth.positive_Eqb_ok' Pos.lt Pos.succ positive_default
+    positive positive_Eqb BuildTriesDepth.positive_Eqb_ok' Pos.lt Pos.succ positive_default Pos.leb
     positive positive_Eqb BuildTriesDepth.positive_Eqb_ok'
     TrieMap.trie_map (fun A => @TrieMapFold.trie_map_ok A) TrieMap.ptree_map_plus
     TrieMap.trie_map (fun A => @TrieMapFold.trie_map_ok A)
@@ -65,17 +65,17 @@ Lemma trie_of_clause_sn_depth
   (Hin : In er (Defs.compiled_rules positive positive TrieMap.trie_map TrieMap.trie_map (brs rf rules)))
   (e : Defs.instance positive positive TrieMap.trie_map TrieMap.trie_map
          (fun A => @FullPosTrie.full_pos_trie_map A) (option positive))
-  (frontier_pos pos : nat) (f n : positive) (cvars : list positive)
+  (window frontier_pos pos : nat) (f n : positive) (cvars : list positive)
   (Hptr : In (Defs.Build_erule_query_ptr positive positive f n cvars)
              (uncurry cons (Defs.query_clause_ptrs positive positive er))) :
   fpt_depth
     (fst (@Defs.trie_of_clause_sn positive positive_Eqb positive
             TrieMap.trie_map TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A)
             (Defs.query_vars positive positive er)
-            (fst (@Defs.build_tries positive positive_Eqb positive TrieMap.trie_map
+            (fst (@Defs.build_tries positive positive_Eqb Pos.succ Pos.leb positive TrieMap.trie_map
                     TrieMap.ptree_map_plus TrieMap.trie_map TrieMap.ptree_map_plus
                     (fun A => @FullPosTrie.full_pos_trie_map A)
-                    (option positive) (brs rf rules) e))
+                    (option positive) window (brs rf rules) e))
             frontier_pos pos
             (Defs.Build_erule_query_ptr positive positive f n cvars)))
     (length cvars).
@@ -83,9 +83,9 @@ Proof.
   cbn [Defs.build_tries fst].
   unfold Defs.trie_of_clause_sn.
   set (DBT := map_intersect
-                (Defs.build_tries_for_symbol positive positive_Eqb TrieMap.trie_map
+                (Defs.build_tries_for_symbol positive positive_Eqb Pos.succ Pos.leb TrieMap.trie_map
                    TrieMap.ptree_map_plus (fun A => @FullPosTrie.full_pos_trie_map A)
-                   (option positive) (Defs.epoch e))
+                   (option positive) (Defs.epoch e) window)
                 (Defs.query_clauses positive positive TrieMap.trie_map TrieMap.trie_map (brs rf rules))
                 (Defs.db e)).
   destruct (compiled_rules_ptr_clen rf rules er Hin f n cvars Hptr)
@@ -99,9 +99,9 @@ Proof.
     (TrieMap.trie_map (list nat * nat))
     (@FullPosTrie.full_pos_trie_map (Defs.db_entry positive (option positive)))
     (TrieMap.trie_map (@FullPosTrie.full_pos_trie_map unit * @FullPosTrie.full_pos_trie_map unit * @FullPosTrie.full_pos_trie_map unit))
-    (Defs.build_tries_for_symbol positive positive_Eqb TrieMap.trie_map
+    (Defs.build_tries_for_symbol positive positive_Eqb Pos.succ Pos.leb TrieMap.trie_map
        TrieMap.ptree_map_plus (fun A => @FullPosTrie.full_pos_trie_map A)
-       (option positive) (Defs.epoch e))
+       (option positive) (Defs.epoch e) window)
     f
     (Defs.query_clauses positive positive TrieMap.trie_map TrieMap.trie_map (brs rf rules))
     (Defs.db e)) in Hdbt.
@@ -114,7 +114,8 @@ Proof.
     pose proof (@BuildTriesDepth.build_tries_for_symbol_depth
       TrieMap.trie_map TrieMap.ptree_map_plus TrieMap.ptree_map_plus_ok
       (option positive)
-      (Defs.epoch e) q_f tbl_f n (cargs, cv) Hgetn)
+      Pos.leb
+      (Defs.epoch e) window q_f tbl_f n (cargs, cv) Hgetn)
       as (ft & Hgetft & Hdf & Hdn & Hdo).
     rewrite <- Heq_tl.
     unfold unwrap_with_default.
@@ -304,12 +305,12 @@ Lemma intersection_inputs_combined_bools
   (Hin : In er (Defs.compiled_rules positive positive TrieMap.trie_map TrieMap.trie_map (brs rf rules)))
   (e : Defs.instance positive positive TrieMap.trie_map TrieMap.trie_map
          (fun A => @FullPosTrie.full_pos_trie_map A) (option positive))
-  (frontier_pos : nat) :
+  (window frontier_pos : nat) :
   let qv := Defs.query_vars positive positive er in
-  let DBT := fst (@Defs.build_tries positive positive_Eqb positive TrieMap.trie_map
+  let DBT := fst (@Defs.build_tries positive positive_Eqb Pos.succ Pos.leb positive TrieMap.trie_map
                     TrieMap.ptree_map_plus TrieMap.trie_map TrieMap.ptree_map_plus
                     (fun A => @FullPosTrie.full_pos_trie_map A)
-                    (option positive) (brs rf rules) e) in
+                    (option positive) window (brs rf rules) e) in
   let toc := fun pos ptr => @Defs.trie_of_clause_sn positive positive_Eqb positive
                 TrieMap.trie_map TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A) qv DBT frontier_pos pos ptr in
   let tries_ne := ne_map_idx toc (Defs.query_clause_ptrs positive positive er) in
@@ -359,7 +360,7 @@ Proof.
     intros j Hj.
     (* Get compile step for NoDup *)
     pose proof (@QueryOptSound.in_compiled_rules_build_rule_set
-      positive positive_Eqb Pos.lt Pos.succ positive_default
+      positive positive_Eqb Pos.lt Pos.succ positive_default Pos.leb
       positive TrieMap.trie_map TrieMap.ptree_map_plus
       TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A)
       rf rules _
@@ -375,7 +376,7 @@ Proof.
     pose proof (@nth_In positive j qvars positive_default Hj) as Hj_in.
     (* compiled_rules_qvar_coverage: get atom covering qvars[j] *)
     pose proof (@QueryOptSound.compiled_rules_qvar_coverage
-      positive positive_Eqb BuildTriesDepth.positive_Eqb_ok' Pos.lt Pos.succ positive_default
+      positive positive_Eqb BuildTriesDepth.positive_Eqb_ok' Pos.lt Pos.succ positive_default Pos.leb
       positive positive_Eqb BuildTriesDepth.positive_Eqb_ok'
       TrieMap.trie_map (fun A => @TrieMapFold.trie_map_ok A) TrieMap.ptree_map_plus
       TrieMap.trie_map (fun A => @TrieMapFold.trie_map_ok A)
@@ -395,7 +396,7 @@ Proof.
     destruct ptr_i as [f_i n_i cvars_i].
     (* compiled_rules_ptr_valid for bounds *)
     pose proof (@QueryOptSound.compiled_rules_ptr_valid
-      positive positive_Eqb BuildTriesDepth.positive_Eqb_ok' Pos.lt Pos.succ positive_default
+      positive positive_Eqb BuildTriesDepth.positive_Eqb_ok' Pos.lt Pos.succ positive_default Pos.leb
       positive positive_Eqb BuildTriesDepth.positive_Eqb_ok'
       TrieMap.trie_map (fun A => @TrieMapFold.trie_map_ok A) TrieMap.ptree_map_plus
       TrieMap.trie_map (fun A => @TrieMapFold.trie_map_ok A)
@@ -510,7 +511,7 @@ Lemma flags_filter_id_len
   = length cvars.
 Proof.
   destruct (@QueryOptSound.compiled_rules_ptr_shape
-    positive positive_Eqb BuildTriesDepth.positive_Eqb_ok' Pos.lt Pos.succ positive_default
+    positive positive_Eqb BuildTriesDepth.positive_Eqb_ok' Pos.lt Pos.succ positive_default Pos.leb
     positive positive_Eqb BuildTriesDepth.positive_Eqb_ok'
     TrieMap.trie_map (fun A => @TrieMapFold.trie_map_ok A) TrieMap.ptree_map_plus
     TrieMap.trie_map (fun A => @TrieMapFold.trie_map_ok A)
@@ -535,16 +536,16 @@ Lemma trie_inputs_fpt_depth_sn
   (Hin : In er (Defs.compiled_rules positive positive TrieMap.trie_map TrieMap.trie_map (brs rf rules)))
   (e : Defs.instance positive positive TrieMap.trie_map TrieMap.trie_map
          (fun A => @FullPosTrie.full_pos_trie_map A) (option positive))
-  (frontier_pos : nat)
+  (window frontier_pos : nat)
   (p : @FullPosTrie.full_pos_trie_map unit * list bool) :
   In p (uncurry cons (ne_map_idx
     (fun pos ptr => @Defs.trie_of_clause_sn positive positive_Eqb positive
        TrieMap.trie_map TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A)
        (Defs.query_vars positive positive er)
-       (fst (@Defs.build_tries positive positive_Eqb positive TrieMap.trie_map
+       (fst (@Defs.build_tries positive positive_Eqb Pos.succ Pos.leb positive TrieMap.trie_map
                TrieMap.ptree_map_plus TrieMap.trie_map TrieMap.ptree_map_plus
                (fun A => @FullPosTrie.full_pos_trie_map A)
-               (option positive) (brs rf rules) e))
+               (option positive) window (brs rf rules) e))
        frontier_pos pos ptr)
     (Defs.query_clause_ptrs positive positive er))) ->
   fpt_depth (fst p) (length (filter id (snd p))).
@@ -553,14 +554,14 @@ Proof.
   destruct (in_ne_map_idx_uncurry_inv _ _ _ Hp) as [pos [ptr [Heqp Hptr]]].
   destruct ptr as [f1 n1 cvars1].
   subst p. cbn beta.
-  pose proof (trie_of_clause_sn_depth rf rules er Hin e frontier_pos pos f1 n1 cvars1 Hptr) as Hd_fpt.
+  pose proof (trie_of_clause_sn_depth rf rules er Hin e window frontier_pos pos f1 n1 cvars1 Hptr) as Hd_fpt.
   assert (Hsnd : snd (@Defs.trie_of_clause_sn positive positive_Eqb positive TrieMap.trie_map
                         TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A)
                         (Defs.query_vars positive positive er)
-                        (fst (@Defs.build_tries positive positive_Eqb positive TrieMap.trie_map
+                        (fst (@Defs.build_tries positive positive_Eqb Pos.succ Pos.leb positive TrieMap.trie_map
                                 TrieMap.ptree_map_plus TrieMap.trie_map TrieMap.ptree_map_plus
                                 (fun A => @FullPosTrie.full_pos_trie_map A)
-                                (option positive) (brs rf rules) e))
+                                (option positive) window (brs rf rules) e))
                         frontier_pos pos
                         (Defs.Build_erule_query_ptr positive positive f1 n1 cvars1))
                 = Defs.variable_flags positive positive_Eqb (Defs.query_vars positive positive er) cvars1).
@@ -579,7 +580,7 @@ Lemma trie_inputs_wf_at_sn
   (Hin : In er (Defs.compiled_rules positive positive TrieMap.trie_map TrieMap.trie_map (brs rf rules)))
   (e : Defs.instance positive positive TrieMap.trie_map TrieMap.trie_map
          (fun A => @FullPosTrie.full_pos_trie_map A) (option positive))
-  (frontier_pos : nat)
+  (window frontier_pos : nat)
   (x : list positive)
   (Hlen : length x = length (Defs.query_vars positive positive er)) :
   let cvt := fun (q : @FullPosTrie.full_pos_trie_map unit * list bool) =>
@@ -587,10 +588,10 @@ Lemma trie_inputs_wf_at_sn
   let toc := fun pos ptr => @Defs.trie_of_clause_sn positive positive_Eqb positive
                TrieMap.trie_map TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A)
                (Defs.query_vars positive positive er)
-               (fst (@Defs.build_tries positive positive_Eqb positive TrieMap.trie_map
+               (fst (@Defs.build_tries positive positive_Eqb Pos.succ Pos.leb positive TrieMap.trie_map
                        TrieMap.ptree_map_plus TrieMap.trie_map TrieMap.ptree_map_plus
                        (fun A => @FullPosTrie.full_pos_trie_map A)
-                       (option positive) (brs rf rules) e))
+                       (option positive) window (brs rf rules) e))
                frontier_pos pos ptr in
   PosListMapIntersectSpec.wf_tries x
     (cvt (fst (ne_map_idx toc (Defs.query_clause_ptrs positive positive er))),
@@ -598,10 +599,10 @@ Lemma trie_inputs_wf_at_sn
 Proof.
   intros cvt toc.
   set (qv := Defs.query_vars positive positive er) in toc, Hlen |- *.
-  set (DBT := fst (@Defs.build_tries positive positive_Eqb positive TrieMap.trie_map
+  set (DBT := fst (@Defs.build_tries positive positive_Eqb Pos.succ Pos.leb positive TrieMap.trie_map
                     TrieMap.ptree_map_plus TrieMap.trie_map TrieMap.ptree_map_plus
                     (fun A => @FullPosTrie.full_pos_trie_map A)
-                    (option positive) (brs rf rules) e)) in toc |- *.
+                    (option positive) window (brs rf rules) e)) in toc |- *.
   unfold PosListMapIntersectSpec.wf_tries.
   (* Helper: for any pos and any ptr in query_clause_ptrs, wf_input x (cvt (toc pos ptr)).
      The (old/new/full) selection only changes the trie, not its depth or its bools,
@@ -623,7 +624,7 @@ Proof.
       cbn [cvt snd fst]. rewrite Hsnd0.
       rewrite @BuildTriesDepth.variable_flags_length. symmetry. exact Hlen.
     + (* depth *)
-      pose proof (trie_of_clause_sn_depth rf rules er Hin e frontier_pos pos f0 n0 cvars0 Hptr0) as Hfd.
+      pose proof (trie_of_clause_sn_depth rf rules er Hin e window frontier_pos pos f0 n0 cvars0 Hptr0) as Hfd.
       cbn [cvt fst snd].
       rewrite Hsnd0.
       unfold qv.
@@ -663,13 +664,13 @@ Lemma trie_intersect_depth_sn
   (Hin : In er (Defs.compiled_rules positive positive TrieMap.trie_map TrieMap.trie_map (brs rf rules)))
   (e : Defs.instance positive positive TrieMap.trie_map TrieMap.trie_map
          (fun A => @FullPosTrie.full_pos_trie_map A) (option positive))
-  (frontier_pos : nat) :
+  (window frontier_pos : nat) :
   let qv := Defs.query_vars positive positive er in
   let N := length qv in
-  let DBT := fst (@Defs.build_tries positive positive_Eqb positive TrieMap.trie_map
+  let DBT := fst (@Defs.build_tries positive positive_Eqb Pos.succ Pos.leb positive TrieMap.trie_map
                     TrieMap.ptree_map_plus TrieMap.trie_map TrieMap.ptree_map_plus
                     (fun A => @FullPosTrie.full_pos_trie_map A)
-                    (option positive) (brs rf rules) e) in
+                    (option positive) window (brs rf rules) e) in
   let toc := fun pos ptr => @Defs.trie_of_clause_sn positive positive_Eqb positive
                TrieMap.trie_map TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A) qv DBT frontier_pos pos ptr in
   let tries_ne := ne_map_idx toc (Defs.query_clause_ptrs positive positive er) in
@@ -682,10 +683,10 @@ Proof.
   intros qv N DBT toc tries_ne cvt.
   set (qv' := Defs.query_vars positive positive er).
   set (N' := length qv').
-  set (DBT' := fst (@Defs.build_tries positive positive_Eqb positive TrieMap.trie_map
+  set (DBT' := fst (@Defs.build_tries positive positive_Eqb Pos.succ Pos.leb positive TrieMap.trie_map
                      TrieMap.ptree_map_plus TrieMap.trie_map TrieMap.ptree_map_plus
                      (fun A => @FullPosTrie.full_pos_trie_map A)
-                     (option positive) (brs rf rules) e)).
+                     (option positive) window (brs rf rules) e)).
   set (toc_fn := fun pos ptr => @Defs.trie_of_clause_sn positive positive_Eqb positive
                     TrieMap.trie_map TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A) qv' DBT' frontier_pos pos ptr).
   set (tries_ne' := ne_map_idx toc_fn (Defs.query_clause_ptrs positive positive er)).
@@ -694,13 +695,13 @@ Proof.
   (* The intro'd let-binders are definitionally equal to the set-bound ones *)
   change (depth (compat_intersect merge_fn (cvt' (fst tries_ne'), map cvt' (snd tries_ne'))) N').
   (* B2 via intersection_inputs_combined_bools *)
-  pose proof (intersection_inputs_combined_bools rf rules er Hin e frontier_pos) as Hb.
+  pose proof (intersection_inputs_combined_bools rf rules er Hin e window frontier_pos) as Hb.
   change (PosListMapIntersectSpec.combined_bools
             (cvt' (fst tries_ne'), map cvt' (snd tries_ne')) = repeat true N') in Hb.
   (* wf_tries at repeat xH N' *)
   assert (Hwf_dummy : PosListMapIntersectSpec.wf_tries (repeat xH N')
     (cvt' (fst tries_ne'), map cvt' (snd tries_ne'))).
-  { apply (trie_inputs_wf_at_sn rf rules er Hin e frontier_pos (repeat xH N')).
+  { apply (trie_inputs_wf_at_sn rf rules er Hin e window frontier_pos (repeat xH N')).
     rewrite repeat_length. reflexivity. }
   (* pt_spaced_intersect_depth *)
   pose proof (@PosListMapIntersectSpec.pt_spaced_intersect_depth unit _
@@ -723,17 +724,18 @@ Lemma trie_join_H9_sn
   (er : Defs.erule positive positive)
   (Hin : In er (Defs.compiled_rules positive positive TrieMap.trie_map TrieMap.trie_map (brs rf rules)))
   (e : Defs.instance positive positive TrieMap.trie_map TrieMap.trie_map
-         (fun A => @FullPosTrie.full_pos_trie_map A) (option positive)) :
+         (fun A => @FullPosTrie.full_pos_trie_map A) (option positive))
+  (window : nat) :
   forall frontier_pos sigma,
     In sigma (@Defs.intersection_keys positive (fun A => @FullPosTrie.full_pos_trie_map A)
                 (@FullPosTrieConv.fpt_spaced_intersect)
                 (ne_map_idx (fun pos ptr => @Defs.trie_of_clause_sn positive positive_Eqb positive
                            TrieMap.trie_map TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A)
                            (Defs.query_vars positive positive er)
-                           (fst (@Defs.build_tries positive positive_Eqb positive TrieMap.trie_map
+                           (fst (@Defs.build_tries positive positive_Eqb Pos.succ Pos.leb positive TrieMap.trie_map
                                    TrieMap.ptree_map_plus TrieMap.trie_map TrieMap.ptree_map_plus
                                    (fun A => @FullPosTrie.full_pos_trie_map A)
-                                   (option positive) (brs rf rules) e))
+                                   (option positive) window (brs rf rules) e))
                            frontier_pos pos ptr)
                          (Defs.query_clause_ptrs positive positive er))) ->
     length (Defs.query_vars positive positive er) = length sigma.
@@ -741,25 +743,25 @@ Proof.
   intros frontier_pos sigma Hin_sig.
   set (qv := Defs.query_vars positive positive er).
   set (N := length qv).
-  set (DBT := fst (@Defs.build_tries positive positive_Eqb positive TrieMap.trie_map
+  set (DBT := fst (@Defs.build_tries positive positive_Eqb Pos.succ Pos.leb positive TrieMap.trie_map
                     TrieMap.ptree_map_plus TrieMap.trie_map TrieMap.ptree_map_plus
                     (fun A => @FullPosTrie.full_pos_trie_map A)
-                    (option positive) (brs rf rules) e)).
+                    (option positive) window (brs rf rules) e)).
   set (toc_fn := fun pos ptr => @Defs.trie_of_clause_sn positive positive_Eqb positive
                    TrieMap.trie_map TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A) qv DBT frontier_pos pos ptr).
   set (tries_ne := ne_map_idx toc_fn (Defs.query_clause_ptrs positive positive er)).
   set (cvt := fun (q : @FullPosTrie.full_pos_trie_map unit * list bool) =>
                (FullPosTrieConv.fpt_to_pt (fst q), snd q)).
   (* Get depth *)
-  pose proof (trie_intersect_depth_sn rf rules er Hin e frontier_pos) as Hdepth.
+  pose proof (trie_intersect_depth_sn rf rules er Hin e window frontier_pos) as Hdepth.
   change (depth (compat_intersect merge_fn (cvt (fst tries_ne), map cvt (snd tries_ne))) N)
     in Hdepth.
   (* Hbools: combined_bools = repeat true N *)
-  pose proof (intersection_inputs_combined_bools rf rules er Hin e frontier_pos) as Hbools.
+  pose proof (intersection_inputs_combined_bools rf rules er Hin e window frontier_pos) as Hbools.
   change (PosListMapIntersectSpec.combined_bools
             (cvt (fst tries_ne), map cvt (snd tries_ne)) = repeat true N) in Hbools.
   (* Hfd: each input has uniform fpt_depth = #true flags *)
-  pose proof (fun q Hq => trie_inputs_fpt_depth_sn rf rules er Hin e frontier_pos q Hq) as Hfd.
+  pose proof (fun q Hq => trie_inputs_fpt_depth_sn rf rules er Hin e window frontier_pos q Hq) as Hfd.
   (* Hlenp: each input's bool list has length = N.
      For each p = toc_fn pos ptr, snd p = variable_flags qv cvars,
      and length (variable_flags qv cvars) = length qv = N. *)
@@ -827,17 +829,18 @@ Lemma trie_join_H10_sn
   (er : Defs.erule positive positive)
   (Hin : In er (Defs.compiled_rules positive positive TrieMap.trie_map TrieMap.trie_map (brs rf rules)))
   (e : Defs.instance positive positive TrieMap.trie_map TrieMap.trie_map
-         (fun A => @FullPosTrie.full_pos_trie_map A) (option positive)) :
+         (fun A => @FullPosTrie.full_pos_trie_map A) (option positive))
+  (window : nat) :
   forall frontier_pos sigma,
     In sigma (@Defs.intersection_keys positive (fun A => @FullPosTrie.full_pos_trie_map A)
                 (@FullPosTrieConv.fpt_spaced_intersect)
                 (ne_map_idx (fun pos ptr => @Defs.trie_of_clause_sn positive positive_Eqb positive
                            TrieMap.trie_map TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A)
                            (Defs.query_vars positive positive er)
-                           (fst (@Defs.build_tries positive positive_Eqb positive TrieMap.trie_map
+                           (fst (@Defs.build_tries positive positive_Eqb Pos.succ Pos.leb positive TrieMap.trie_map
                                    TrieMap.ptree_map_plus TrieMap.trie_map TrieMap.ptree_map_plus
                                    (fun A => @FullPosTrie.full_pos_trie_map A)
-                                   (option positive) (brs rf rules) e))
+                                   (option positive) window (brs rf rules) e))
                            frontier_pos pos ptr)
                          (Defs.query_clause_ptrs positive positive er))) ->
     forall pos fsym nptr cvars,
@@ -847,10 +850,10 @@ Lemma trie_join_H10_sn
         (fst (@Defs.trie_of_clause_sn positive positive_Eqb positive
                 TrieMap.trie_map TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A)
                 (Defs.query_vars positive positive er)
-                (fst (@Defs.build_tries positive positive_Eqb positive TrieMap.trie_map
+                (fst (@Defs.build_tries positive positive_Eqb Pos.succ Pos.leb positive TrieMap.trie_map
                         TrieMap.ptree_map_plus TrieMap.trie_map TrieMap.ptree_map_plus
                         (fun A => @FullPosTrie.full_pos_trie_map A)
-                        (option positive) (brs rf rules) e))
+                        (option positive) window (brs rf rules) e))
                 frontier_pos pos
                 (Defs.Build_erule_query_ptr positive positive fsym nptr cvars)))
         (map fst (filter snd (combine sigma
@@ -861,10 +864,10 @@ Proof.
   intros frontier_pos sigma Hin_sig pos fsym nptr cvars Hnth.
   set (qv := Defs.query_vars positive positive er).
   set (N := length qv).
-  set (DBT := fst (@Defs.build_tries positive positive_Eqb positive TrieMap.trie_map
+  set (DBT := fst (@Defs.build_tries positive positive_Eqb Pos.succ Pos.leb positive TrieMap.trie_map
                     TrieMap.ptree_map_plus TrieMap.trie_map TrieMap.ptree_map_plus
                     (fun A => @FullPosTrie.full_pos_trie_map A)
-                    (option positive) (brs rf rules) e)).
+                    (option positive) window (brs rf rules) e)).
   set (toc_fn := fun pos ptr => @Defs.trie_of_clause_sn positive positive_Eqb positive
                    TrieMap.trie_map TrieMap.trie_map (fun A => @FullPosTrie.full_pos_trie_map A) qv DBT frontier_pos pos ptr).
   set (tries_ne := ne_map_idx toc_fn (Defs.query_clause_ptrs positive positive er)).
@@ -872,18 +875,18 @@ Proof.
                (FullPosTrieConv.fpt_to_pt (fst q), snd q)).
   set (R := compat_intersect merge_fn (cvt (fst tries_ne), map cvt (snd tries_ne))).
   (* H9: length sigma = N *)
-  pose proof (trie_join_H9_sn rf rules er Hin e frontier_pos sigma Hin_sig) as Hlen.
+  pose proof (trie_join_H9_sn rf rules er Hin e window frontier_pos sigma Hin_sig) as Hlen.
   (* Hlen : N = length sigma; so length sigma = N via symmetry *)
   (* Hbools *)
-  pose proof (intersection_inputs_combined_bools rf rules er Hin e frontier_pos) as Hbools.
+  pose proof (intersection_inputs_combined_bools rf rules er Hin e window frontier_pos) as Hbools.
   change (PosListMapIntersectSpec.combined_bools
             (cvt (fst tries_ne), map cvt (snd tries_ne)) = repeat true N) in Hbools.
   (* Hdepth *)
-  pose proof (trie_intersect_depth_sn rf rules er Hin e frontier_pos) as Hdepth.
+  pose proof (trie_intersect_depth_sn rf rules er Hin e window frontier_pos) as Hdepth.
   change (depth (compat_intersect merge_fn (cvt (fst tries_ne), map cvt (snd tries_ne))) N)
     in Hdepth.
   (* wf_tries sigma *)
-  pose proof (trie_inputs_wf_at_sn rf rules er Hin e frontier_pos sigma (eq_sym Hlen)) as Hwf.
+  pose proof (trie_inputs_wf_at_sn rf rules er Hin e window frontier_pos sigma (eq_sym Hlen)) as Hwf.
   change (PosListMapIntersectSpec.wf_tries sigma
             (cvt (fst tries_ne), map cvt (snd tries_ne))) in Hwf.
   (* Unfold intersection_keys in Hin_sig *)
@@ -915,7 +918,7 @@ Proof.
                 merge_fn merge_comm_pf merge_assoc_pf
                 (fst tries_ne) (snd tries_ne) sigma N
                 Hin_sig (eq_sym Hlen) Hdepth Hbools Hwf
-                (fun q Hq => trie_inputs_fpt_depth_sn rf rules er Hin e frontier_pos q Hq)
+                (fun q Hq => trie_inputs_fpt_depth_sn rf rules er Hin e window frontier_pos q Hq)
                 p Hp_in) as (v & Hv).
   (* Hv : fpt_get (fst p) (map fst (filter snd (combine sigma (snd p)))) = Some v *)
   (* Goal has variable_flags qv cvars. Rewrite <-Hsnd_p to get snd p in goal. *)

--- a/src/Utils/EGraph/QueryOptSound.v
+++ b/src/Utils/EGraph/QueryOptSound.v
@@ -5119,34 +5119,36 @@ Section WithMap.
       (forall rule, In rule rules ->
          model_satisfies_rule m (QueryOpt.optimize_sequent idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie rule rf)) ->
       In er (compiled_rules idx symbol symbol_map idx_map (QueryOpt.build_rule_set idx_succ idx_zero rf rules)) ->
-      (forall frontier_n sigma,
+      (forall frontier_pos sigma,
          In sigma (intersection_keys idx idx_trie spaced_list_intersect
-                     (ne_map (trie_of_clause idx Eqb_idx symbol symbol_map idx_map idx_trie
-                                (query_vars idx symbol er)
-                                (fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
-                                        idx_map idx_map_plus idx_trie A
-                                        (QueryOpt.build_rule_set idx_succ idx_zero rf rules) e))
-                                frontier_n)
-                             (query_clause_ptrs idx symbol er))) ->
+                     (ne_map_idx (fun pos ptr =>
+                                    trie_of_clause_sn idx Eqb_idx symbol symbol_map idx_map idx_trie
+                                      (query_vars idx symbol er)
+                                      (fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
+                                              idx_map idx_map_plus idx_trie A
+                                              (QueryOpt.build_rule_set idx_succ idx_zero rf rules) e))
+                                      frontier_pos pos ptr)
+                                 (query_clause_ptrs idx symbol er))) ->
          List.length (query_vars idx symbol er) = List.length sigma) ->
-      (forall frontier_n sigma,
+      (forall frontier_pos sigma,
          In sigma (intersection_keys idx idx_trie spaced_list_intersect
-                     (ne_map (trie_of_clause idx Eqb_idx symbol symbol_map idx_map idx_trie
-                                (query_vars idx symbol er)
-                                (fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
-                                        idx_map idx_map_plus idx_trie A
-                                        (QueryOpt.build_rule_set idx_succ idx_zero rf rules) e))
-                                frontier_n)
-                             (query_clause_ptrs idx symbol er))) ->
-         forall fsym nptr cvars,
-         In (Build_erule_query_ptr idx symbol fsym nptr cvars)
-            (uncurry cons (query_clause_ptrs idx symbol er)) ->
-         map.get (fst (trie_of_clause idx Eqb_idx symbol symbol_map idx_map idx_trie
+                     (ne_map_idx (fun pos ptr =>
+                                    trie_of_clause_sn idx Eqb_idx symbol symbol_map idx_map idx_trie
+                                      (query_vars idx symbol er)
+                                      (fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
+                                              idx_map idx_map_plus idx_trie A
+                                              (QueryOpt.build_rule_set idx_succ idx_zero rf rules) e))
+                                      frontier_pos pos ptr)
+                                 (query_clause_ptrs idx symbol er))) ->
+         forall pos fsym nptr cvars,
+         nth_error (uncurry cons (query_clause_ptrs idx symbol er)) pos
+           = Some (Build_erule_query_ptr idx symbol fsym nptr cvars) ->
+         map.get (fst (trie_of_clause_sn idx Eqb_idx symbol symbol_map idx_map idx_trie
                          (query_vars idx symbol er)
                          (fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
                                  idx_map idx_map_plus idx_trie A
                                  (QueryOpt.build_rule_set idx_succ idx_zero rf rules) e))
-                         frontier_n
+                         frontier_pos pos
                          (Build_erule_query_ptr idx symbol fsym nptr cvars)))
                  (map fst (filter snd (combine sigma
                     (variable_flags idx Eqb_idx (query_vars idx symbol er) cvars))))

--- a/src/Utils/EGraph/QueryOptSound.v
+++ b/src/Utils/EGraph/QueryOptSound.v
@@ -48,6 +48,7 @@ Section WithMap.
       (lt : idx -> idx -> Prop)
       (idx_succ : idx -> idx)
       (idx_zero : WithDefault idx)
+      (idx_leb : idx -> idx -> bool)
     (symbol : Type)
       (Eqb_symbol : Eqb symbol)
       (Eqb_symbol_ok : Eqb_ok Eqb_symbol)
@@ -5113,7 +5114,8 @@ Section WithMap.
     (spaced_list_intersect : forall B, WithDefault B -> (B -> B -> B) ->
           ne_list (idx_trie B * list bool) -> idx_trie B)
     (A : Type) (HA : analysis idx symbol A) :
-    forall (m : model symbol) (Hm : Semantics.model_ok symbol m)
+    forall (window : nat)
+           (m : model symbol) (Hm : Semantics.model_ok symbol m)
            (rf : nat) (rules : list sequent) (er : erule idx symbol)
            (e : Defs.instance idx symbol symbol_map idx_map idx_trie A),
       (forall rule, In rule rules ->
@@ -5124,8 +5126,8 @@ Section WithMap.
                      (ne_map_idx (fun pos ptr =>
                                     trie_of_clause_sn idx Eqb_idx symbol symbol_map idx_map idx_trie
                                       (query_vars idx symbol er)
-                                      (fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
-                                              idx_map idx_map_plus idx_trie A
+                                      (fst (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
+                                              idx_map idx_map_plus idx_trie A window
                                               (QueryOpt.build_rule_set idx_succ idx_zero rf rules) e))
                                       frontier_pos pos ptr)
                                  (query_clause_ptrs idx symbol er))) ->
@@ -5135,8 +5137,8 @@ Section WithMap.
                      (ne_map_idx (fun pos ptr =>
                                     trie_of_clause_sn idx Eqb_idx symbol symbol_map idx_map idx_trie
                                       (query_vars idx symbol er)
-                                      (fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
-                                              idx_map idx_map_plus idx_trie A
+                                      (fst (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
+                                              idx_map idx_map_plus idx_trie A window
                                               (QueryOpt.build_rule_set idx_succ idx_zero rf rules) e))
                                       frontier_pos pos ptr)
                                  (query_clause_ptrs idx symbol er))) ->
@@ -5145,19 +5147,19 @@ Section WithMap.
            = Some (Build_erule_query_ptr idx symbol fsym nptr cvars) ->
          map.get (fst (trie_of_clause_sn idx Eqb_idx symbol symbol_map idx_map idx_trie
                          (query_vars idx symbol er)
-                         (fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
-                                 idx_map idx_map_plus idx_trie A
+                         (fst (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
+                                 idx_map idx_map_plus idx_trie A window
                                  (QueryOpt.build_rule_set idx_succ idx_zero rf rules) e))
                          frontier_pos pos
                          (Build_erule_query_ptr idx symbol fsym nptr cvars)))
                  (map fst (filter snd (combine sigma
                     (variable_flags idx Eqb_idx (query_vars idx symbol er) cvars))))
          = Some tt) ->
-      SemanticsSaturate.run1iter_rule_hyps idx Eqb_idx idx_zero symbol symbol_map symbol_map_plus
+      SemanticsSaturate.run1iter_rule_hyps idx Eqb_idx idx_zero idx_succ idx_leb window symbol symbol_map symbol_map_plus
         idx_map idx_map_plus idx_trie A spaced_list_intersect m
         (QueryOpt.build_rule_set idx_succ idx_zero rf rules) e er.
   Proof.
-    intros m Hm rf rules er e Hmsr Hin H9 H10.
+    intros window m Hm rf rules er e Hmsr Hin H9 H10.
     unfold SemanticsSaturate.run1iter_rule_hyps.
     cbn zeta.
     pose proof (in_compiled_rules_build_rule_set rf rules er Hin) as (rule & st0 & st1 & _ & Hc).

--- a/src/Utils/EGraph/Semantics.v
+++ b/src/Utils/EGraph/Semantics.v
@@ -660,12 +660,13 @@ Section WithMap.
     (current_epoch : idx)
     (q_clauses : idx_map (list nat * nat))
     (tbl : idx_trie (db_entry idx analysis_result))
-    (n : idx) (clause : list nat * nat) (trie_pair : idx_trie unit * idx_trie unit)
+    (n : idx) (clause : list nat * nat)
+    (trie_pair : idx_trie unit * idx_trie unit * idx_trie unit)
     (assignment : list idx) :
     map.get q_clauses n = Some clause ->
     map.get (build_tries_for_symbol idx Eqb_idx idx_map idx_map_plus idx_trie
                analysis_result current_epoch q_clauses tbl) n = Some trie_pair ->
-    map.get (fst trie_pair) assignment = Some tt ->
+    map.get (fst (fst trie_pair)) assignment = Some tt ->
     exists args entry,
       map.get tbl args = Some entry
       /\ match_clause clause args (entry.(entry_value idx analysis_result)) = Some assignment.
@@ -674,16 +675,16 @@ Section WithMap.
     intros Hqn Hget Hfull.
     revert trie_pair Hget Hfull.
     eapply (@map.fold_spec (list idx) (db_entry idx analysis_result) (idx_trie _) (idx_trie_ok _)
-      (idx_map (idx_trie unit * idx_trie unit))
+      (idx_map (idx_trie unit * idx_trie unit * idx_trie unit))
       (fun tbl_processed tries =>
         forall trie_pair,
         map.get tries n = Some trie_pair ->
-        map.get (fst trie_pair) assignment = Some tt ->
+        map.get (fst (fst trie_pair)) assignment = Some tt ->
         exists args entry,
           map.get tbl_processed args = Some entry
           /\ match_clause clause args (entry_value idx analysis_result entry) = Some assignment));
       [ | ].
-    - (* Base case: accumulator = map_map (fun _ => (empty, empty)) q_clauses *)
+    - (* Base case: accumulator = map_map (fun _ => (empty, empty, empty)) q_clauses *)
       intros tp Htp Hfull.
       rewrite (@map_map_spec _ idx_map _ idx_map_plus_ok) in Htp.
       rewrite Hqn in Htp.
@@ -702,7 +703,7 @@ Section WithMap.
       2: { discriminate. }
       injection Hqn; intro; subst cl.
       injection Htp; intro; subst tp.
-      destruct tp_old as [ full_old frontier_old ].
+      destruct tp_old as [ [ full_old new_old ] old_old ].
       cbn [fst] in Hfull.
       destruct (match_clause clause k vv) as [ assignment0 | ] eqn:Hmatch.
       { (* Match succeeded: assignment0 was recorded in full *)
@@ -721,7 +722,7 @@ Section WithMap.
             rewrite Heqasg in Hbs.
             rewrite (get_put_diff_trie unit full_old assignment assignment0 tt
               (fun H => Hbs (eq_sym H))) in Hfull.
-            destruct (IH (full_old, frontier_old) eq_refl Hfull)
+            destruct (IH (full_old, new_old, old_old) eq_refl Hfull)
               as [ args [ entry [ Hargs Hentry ] ] ].
             exists args. exists entry.
             split.
@@ -743,7 +744,7 @@ Section WithMap.
             rewrite Heqasg in Hbs.
             rewrite (get_put_diff_trie unit full_old assignment assignment0 tt
               (fun H => Hbs (eq_sym H))) in Hfull.
-            destruct (IH (full_old, frontier_old) eq_refl Hfull)
+            destruct (IH (full_old, new_old, old_old) eq_refl Hfull)
               as [ args [ entry [ Hargs Hentry ] ] ].
             exists args. exists entry.
             split.
@@ -751,9 +752,9 @@ Section WithMap.
               ** exact Hargs.
               ** intro Heq'. subst args. rewrite Hnotk in Hargs. discriminate.
             * exact Hentry. }
-      { (* Match failed: (full, frontier) unchanged, use IH directly *)
+      { (* Match failed: triple unchanged, use IH directly *)
         cbn [fst] in Hfull.
-        destruct (IH (full_old, frontier_old) eq_refl Hfull)
+        destruct (IH (full_old, new_old, old_old) eq_refl Hfull)
           as [ args [ entry [ Hargs Hentry ] ] ].
         exists args. exists entry.
         split.
@@ -766,15 +767,15 @@ Section WithMap.
   Lemma build_tries_sound (q : rule_set idx symbol symbol_map idx_map)
     (inst : instance)
     (f : symbol) (n : idx) (clause : list nat * nat)
-    (clause_tries : idx_map (idx_trie unit * idx_trie unit))
-    (trie_pair : idx_trie unit * idx_trie unit) (assignment : list idx)
+    (clause_tries : idx_map (idx_trie unit * idx_trie unit * idx_trie unit))
+    (trie_pair : idx_trie unit * idx_trie unit * idx_trie unit) (assignment : list idx)
     (q_f : idx_map (list nat * nat)) :
     map.get (q.(query_clauses idx symbol symbol_map idx_map)) f = Some q_f ->
     map.get q_f n = Some clause ->
     map.get (fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
       idx_map idx_map_plus idx_trie analysis_result q inst)) f = Some clause_tries ->
     map.get clause_tries n = Some trie_pair ->
-    map.get (fst trie_pair) assignment = Some tt ->
+    map.get (fst (fst trie_pair)) assignment = Some tt ->
     exists args v,
       atom_in_db (Build_atom f args v) inst.(db)
       /\ match_clause clause args v = Some assignment.
@@ -807,22 +808,22 @@ Section WithMap.
   Lemma build_tries_for_symbol_frontier_subset
     (current_epoch : idx) (q_clauses : idx_map (list nat * nat))
     (tbl : idx_trie (db_entry idx analysis_result))
-    (n : idx) (trie_pair : idx_trie unit * idx_trie unit) (assignment : list idx) :
+    (n : idx) (trie_pair : idx_trie unit * idx_trie unit * idx_trie unit) (assignment : list idx) :
     map.get (build_tries_for_symbol idx Eqb_idx idx_map idx_map_plus idx_trie
                analysis_result current_epoch q_clauses tbl) n = Some trie_pair ->
-    map.get (snd trie_pair) assignment = Some tt ->
-    map.get (fst trie_pair) assignment = Some tt.
+    map.get (snd (fst trie_pair)) assignment = Some tt ->
+    map.get (fst (fst trie_pair)) assignment = Some tt.
   Proof.
     intros Hget Hfrontier.
     revert trie_pair Hget Hfrontier.
     unfold build_tries_for_symbol.
     eapply (@map.fold_spec (list idx) (db_entry idx analysis_result) (idx_trie _) (idx_trie_ok _)
-      (idx_map (idx_trie unit * idx_trie unit))
+      (idx_map (idx_trie unit * idx_trie unit * idx_trie unit))
       (fun _tbl_processed tries =>
         forall tp,
         map.get tries n = Some tp ->
-        map.get (snd tp) assignment = Some tt ->
-        map.get (fst tp) assignment = Some tt));
+        map.get (snd (fst tp)) assignment = Some tt ->
+        map.get (fst (fst tp)) assignment = Some tt));
       [ | ].
     - (* Base case *)
       intros tp Htp Hfront.
@@ -830,7 +831,7 @@ Section WithMap.
       destruct (map.get q_clauses n) as [ cl | ] eqn:Hcl.
       + cbn [option_map] in Htp.
         injection Htp; intro; subst tp.
-        cbn [snd] in Hfront.
+        cbn [snd fst] in Hfront.
         rewrite (@map.get_empty _ _ _ (idx_trie_ok unit)) in Hfront.
         discriminate.
       + cbn [option_map] in Htp. discriminate.
@@ -843,10 +844,10 @@ Section WithMap.
       destruct (map.get q_clauses n) as [ cl | ] eqn:Hcl.
       2: { discriminate. }
       injection Htp; intro; subst tp.
-      destruct tp_old as [ full_old frontier_old ].
+      destruct tp_old as [ [ full_old new_old ] old_old ].
       destruct (match_clause cl k vv) as [ assignment0 | ] eqn:Hmatch.
       { destruct (eqb epoch current_epoch) eqn:Hepoch.
-        - (* epoch matches: frontier' = put frontier_old assignment0 tt *)
+        - (* epoch matches: new' = put new_old assignment0 tt *)
           cbn [fst snd] in *.
           destruct (eqb (assignment0 : list idx) assignment) eqn:Heqasg.
           + pose proof (@eqb_spec (list idx) (list_eqb (A:=idx))
@@ -856,17 +857,17 @@ Section WithMap.
           + pose proof (@eqb_spec (list idx) (list_eqb (A:=idx))
               (@list_eqb_ok idx Eqb_idx Eqb_idx_ok) assignment0 assignment) as Hbs.
             rewrite Heqasg in Hbs.
-            rewrite (get_put_diff_trie unit frontier_old assignment assignment0 tt
+            rewrite (get_put_diff_trie unit new_old assignment assignment0 tt
               (fun H => Hbs (eq_sym H))) in Hfront.
-            pose proof (IH (full_old, frontier_old) eq_refl) as HIH.
+            pose proof (IH (full_old, new_old, old_old) eq_refl) as HIH.
             cbn [fst snd] in HIH.
             pose proof (HIH Hfront) as Hfull_old.
             rewrite (get_put_diff_trie unit full_old assignment assignment0 tt
               (fun H => Hbs (eq_sym H))).
             exact Hfull_old.
-        - (* epoch doesn't match: frontier' = frontier_old unchanged *)
+        - (* epoch doesn't match: new' = new_old unchanged *)
           cbn [fst snd] in *.
-          pose proof (IH (full_old, frontier_old) eq_refl) as HIH.
+          pose proof (IH (full_old, new_old, old_old) eq_refl) as HIH.
           cbn [fst snd] in HIH.
           pose proof (HIH Hfront) as Hfull_old.
           destruct (eqb (assignment0 : list idx) assignment) eqn:Heqasg.
@@ -880,21 +881,21 @@ Section WithMap.
             rewrite (get_put_diff_trie unit full_old assignment assignment0 tt
               (fun H => Hbs (eq_sym H))).
             exact Hfull_old. }
-      { (* Match failed: pair unchanged *)
+      { (* Match failed: triple unchanged *)
         cbn [fst snd] in *.
-        exact (IH (full_old, frontier_old) eq_refl Hfront). }
+        exact (IH (full_old, new_old, old_old) eq_refl Hfront). }
   Qed.
 
   Lemma build_tries_frontier_subset (q : rule_set idx symbol symbol_map idx_map)
     (inst : instance)
     (f : symbol) (n : idx)
-    (clause_tries : idx_map (idx_trie unit * idx_trie unit))
-    (trie_pair : idx_trie unit * idx_trie unit) (assignment : list idx) :
+    (clause_tries : idx_map (idx_trie unit * idx_trie unit * idx_trie unit))
+    (trie_pair : idx_trie unit * idx_trie unit * idx_trie unit) (assignment : list idx) :
     map.get (fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
       idx_map idx_map_plus idx_trie analysis_result q inst)) f = Some clause_tries ->
     map.get clause_tries n = Some trie_pair ->
-    map.get (snd trie_pair) assignment = Some tt ->
-    map.get (fst trie_pair) assignment = Some tt.
+    map.get (snd (fst trie_pair)) assignment = Some tt ->
+    map.get (fst (fst trie_pair)) assignment = Some tt.
   Proof.
     intros Hbt_f Hct_n Hfront.
     unfold build_tries in Hbt_f. cbn [fst] in Hbt_f.
@@ -945,29 +946,232 @@ Section WithMap.
       fold db_tries in Hhit.
       rewrite Hf in Hhit.
       cbn [fst snd] in Hhit.
-      destruct (map.get trie_list n) as [ [ total frontier ] | ] eqn:Hn.
-      + (* map.get trie_list n = Some (total, frontier) *)
+      destruct (map.get trie_list n) as [ [ [ total new_ ] old_ ] | ] eqn:Hn.
+      + (* map.get trie_list n = Some (total, new_, old_) *)
         cbn [unwrap_with_default fst snd] in Hhit.
         destruct (eqb n frontier_n) eqn:Hn_eq.
-        * (* eqb n frontier_n = true, frontier case *)
+        * (* eqb n frontier_n = true, new_ case *)
           fold proj in Hhit.
-          assert (Hfull : map.get (fst (total, frontier)) proj = Some tt). {
-            apply (build_tries_frontier_subset q inst f n trie_list (total, frontier) proj Hf Hn).
+          assert (Hfull : map.get (fst (fst (total, new_, old_))) proj = Some tt). {
+            apply (build_tries_frontier_subset q inst f n trie_list (total, new_, old_) proj Hf Hn).
             exact Hhit.
           }
           cbn [fst] in Hfull.
-          pose proof (build_tries_sound q inst f n clause trie_list (total, frontier) proj q_f Hqf Hclause Hf Hn Hfull)
+          pose proof (build_tries_sound q inst f n clause trie_list (total, new_, old_) proj q_f Hqf Hclause Hf Hn Hfull)
             as [ args [ v [Hdb Hmatch] ] ].
           exists args. exists v.
           exact (conj Hdb Hmatch).
         * (* eqb n frontier_n = false, total case *)
           fold proj in Hhit.
-          pose proof (build_tries_sound q inst f n clause trie_list (total, frontier) proj q_f Hqf Hclause Hf Hn Hhit)
+          pose proof (build_tries_sound q inst f n clause trie_list (total, new_, old_) proj q_f Hqf Hclause Hf Hn Hhit)
             as [ args [ v [Hdb Hmatch] ] ].
           exists args. exists v.
           exact (conj Hdb Hmatch).
       + (* map.get trie_list n = None *)
         destruct (eqb n frontier_n) in Hhit;
+        cbn [fst] in Hhit;
+        rewrite (@map.get_empty _ _ _ (idx_trie_ok unit)) in Hhit;
+        discriminate.
+    - (* map.get db_tries f = None *)
+      fold db_tries in Hhit.
+      rewrite Hf in Hhit.
+      cbn [fst] in Hhit.
+      rewrite (@map.get_empty _ _ _ (idx_trie_ok unit)) in Hhit.
+      discriminate.
+  Qed.
+
+  (* OLD subset (mirror of *_frontier_subset for the [old] component): a hit in
+     [old] (= snd) implies a hit in [full] (= fst (fst)).  Needed for the proper
+     semi-naive 3-way selection where clauses before the frontier use [old]. *)
+  Lemma build_tries_for_symbol_old_subset
+    (current_epoch : idx) (q_clauses : idx_map (list nat * nat))
+    (tbl : idx_trie (db_entry idx analysis_result))
+    (n : idx) (trie_pair : idx_trie unit * idx_trie unit * idx_trie unit) (assignment : list idx) :
+    map.get (build_tries_for_symbol idx Eqb_idx idx_map idx_map_plus idx_trie
+               analysis_result current_epoch q_clauses tbl) n = Some trie_pair ->
+    map.get (snd trie_pair) assignment = Some tt ->
+    map.get (fst (fst trie_pair)) assignment = Some tt.
+  Proof.
+    intros Hget Hfront.
+    revert trie_pair Hget Hfront.
+    unfold build_tries_for_symbol.
+    eapply (@map.fold_spec (list idx) (db_entry idx analysis_result) (idx_trie _) (idx_trie_ok _)
+      (idx_map (idx_trie unit * idx_trie unit * idx_trie unit))
+      (fun _tbl_processed tries =>
+        forall tp,
+        map.get tries n = Some tp ->
+        map.get (snd tp) assignment = Some tt ->
+        map.get (fst (fst tp)) assignment = Some tt));
+      [ | ].
+    - (* Base case *)
+      intros tp Htp Hfront.
+      rewrite (@map_map_spec _ idx_map _ idx_map_plus_ok) in Htp.
+      destruct (map.get q_clauses n) as [ cl | ] eqn:Hcl.
+      + cbn [option_map] in Htp.
+        injection Htp; intro; subst tp.
+        cbn [snd fst] in Hfront.
+        rewrite (@map.get_empty _ _ _ (idx_trie_ok unit)) in Hfront.
+        discriminate.
+      + cbn [option_map] in Htp. discriminate.
+    - (* Step case *)
+      intros k v m_partial r Hnotk IH tp Htp Hfront.
+      destruct v as [ epoch vv va ].
+      rewrite (@intersect_spec _ idx_map _ idx_map_plus_ok) in Htp.
+      destruct (map.get r n) as [ tp_old | ] eqn:Htp_old.
+      2: { destruct (map.get q_clauses n); discriminate. }
+      destruct (map.get q_clauses n) as [ cl | ] eqn:Hcl.
+      2: { discriminate. }
+      injection Htp; intro; subst tp.
+      destruct tp_old as [ [ full_old new_old ] old_old ].
+      destruct (match_clause cl k vv) as [ assignment0 | ] eqn:Hmatch.
+      { destruct (eqb epoch current_epoch) eqn:Hepoch.
+        - (* epoch matches: old' = old_old (unchanged), full' = put full_old asg0 *)
+          cbn [fst snd] in *.
+          (* Hfront : map.get old_old assignment = Some tt *)
+          pose proof (IH (full_old, new_old, old_old) eq_refl) as HIH.
+          cbn [fst snd] in HIH.
+          pose proof (HIH Hfront) as Hfull_old.
+          destruct (eqb (assignment0 : list idx) assignment) eqn:Heqasg.
+          + pose proof (@eqb_spec (list idx) (list_eqb (A:=idx))
+              (@list_eqb_ok idx Eqb_idx Eqb_idx_ok) assignment0 assignment) as Hbs.
+            rewrite Heqasg in Hbs. subst assignment0.
+            apply (@map.get_put_same _ _ _ (idx_trie_ok unit)).
+          + pose proof (@eqb_spec (list idx) (list_eqb (A:=idx))
+              (@list_eqb_ok idx Eqb_idx Eqb_idx_ok) assignment0 assignment) as Hbs.
+            rewrite Heqasg in Hbs.
+            rewrite (get_put_diff_trie unit full_old assignment assignment0 tt
+              (fun H => Hbs (eq_sym H))).
+            exact Hfull_old.
+        - (* epoch doesn't match: old' = put old_old asg0, full' = put full_old asg0 *)
+          cbn [fst snd] in *.
+          destruct (eqb (assignment0 : list idx) assignment) eqn:Heqasg.
+          + pose proof (@eqb_spec (list idx) (list_eqb (A:=idx))
+              (@list_eqb_ok idx Eqb_idx Eqb_idx_ok) assignment0 assignment) as Hbs.
+            rewrite Heqasg in Hbs. subst assignment0.
+            apply (@map.get_put_same _ _ _ (idx_trie_ok unit)).
+          + pose proof (@eqb_spec (list idx) (list_eqb (A:=idx))
+              (@list_eqb_ok idx Eqb_idx Eqb_idx_ok) assignment0 assignment) as Hbs.
+            rewrite Heqasg in Hbs.
+            rewrite (get_put_diff_trie unit old_old assignment assignment0 tt
+              (fun H => Hbs (eq_sym H))) in Hfront.
+            pose proof (IH (full_old, new_old, old_old) eq_refl) as HIH.
+            cbn [fst snd] in HIH.
+            pose proof (HIH Hfront) as Hfull_old.
+            rewrite (get_put_diff_trie unit full_old assignment assignment0 tt
+              (fun H => Hbs (eq_sym H))).
+            exact Hfull_old. }
+      { (* Match failed: triple unchanged *)
+        cbn [fst snd] in *.
+        exact (IH (full_old, new_old, old_old) eq_refl Hfront). }
+  Qed.
+
+  Lemma build_tries_old_subset (q : rule_set idx symbol symbol_map idx_map)
+    (inst : instance)
+    (f : symbol) (n : idx)
+    (clause_tries : idx_map (idx_trie unit * idx_trie unit * idx_trie unit))
+    (trie_pair : idx_trie unit * idx_trie unit * idx_trie unit) (assignment : list idx) :
+    map.get (fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
+      idx_map idx_map_plus idx_trie analysis_result q inst)) f = Some clause_tries ->
+    map.get clause_tries n = Some trie_pair ->
+    map.get (snd trie_pair) assignment = Some tt ->
+    map.get (fst (fst trie_pair)) assignment = Some tt.
+  Proof.
+    intros Hbt_f Hct_n Hfront.
+    unfold build_tries in Hbt_f. cbn [fst] in Hbt_f.
+    rewrite (@intersect_spec _ symbol_map _ symbol_map_plus_ok) in Hbt_f.
+    destruct (map.get (query_clauses idx symbol symbol_map idx_map q) f) as [ q_f | ] eqn:Hqf.
+    - destruct (map.get inst.(db) f) as [ tbl | ] eqn:Htbl.
+      + unfold db_map in Htbl.
+        rewrite Htbl in Hbt_f.
+        injection Hbt_f; intro; subst clause_tries.
+        apply (build_tries_for_symbol_old_subset (inst.(epoch)) q_f tbl n trie_pair assignment
+          Hct_n Hfront).
+      + unfold db_map in Htbl.
+        rewrite Htbl in Hbt_f.
+        cbn in Hbt_f. discriminate.
+    - cbn in Hbt_f. discriminate.
+  Qed.
+
+  (* 3-way version of clause_ptr_atom_in_db for the proper semi-naive selection
+     [trie_of_clause_sn frontier_pos pos]: a hit in the selected trie
+     (old if pos<frontier_pos, new if =, full if >) reduces to a db atom via the
+     subset lemmas + build_tries_sound. *)
+  Lemma clause_ptr_atom_in_db_sn
+    (q : rule_set idx symbol symbol_map idx_map) (inst : instance)
+    (query_vars : list idx) (frontier_pos pos : nat)
+    (f : symbol) (n : idx) (clause_vars : list idx)
+    (q_f : idx_map (list nat * nat)) (clause : list nat * nat)
+    (sigma : list idx) :
+    map.get (query_clauses idx symbol symbol_map idx_map q) f = Some q_f ->
+    map.get q_f n = Some clause ->
+    map.get (fst (trie_of_clause_sn idx Eqb_idx symbol symbol_map idx_map idx_trie
+                    query_vars
+                    (fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
+                            idx_map idx_map_plus idx_trie analysis_result q inst))
+                    frontier_pos pos (Build_erule_query_ptr idx symbol f n clause_vars)))
+            (map fst (filter snd (combine sigma
+               (variable_flags idx Eqb_idx query_vars clause_vars))))
+          = Some tt ->
+    exists args v,
+      atom_in_db (Build_atom f args v) inst.(db)
+      /\ match_clause clause args v
+         = Some (map fst (filter snd (combine sigma
+                   (variable_flags idx Eqb_idx query_vars clause_vars)))).
+  Proof.
+    intros Hqf Hclause Hhit.
+    unfold trie_of_clause_sn in Hhit.
+    cbn [fst snd] in Hhit.
+    set (proj := map fst (filter snd (combine sigma (variable_flags idx Eqb_idx query_vars clause_vars)))).
+    set (db_tries := fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
+                            idx_map idx_map_plus idx_trie analysis_result q inst)).
+    destruct (map.get db_tries f) as [ trie_list | ] eqn:Hf.
+    - (* Some trie_list case *)
+      fold db_tries in Hhit.
+      rewrite Hf in Hhit.
+      cbn [fst snd] in Hhit.
+      destruct (map.get trie_list n) as [ [ [ full new_ ] old_ ] | ] eqn:Hn.
+      + (* map.get trie_list n = Some (full, new_, old_) *)
+        cbn [unwrap_with_default fst snd] in Hhit.
+        destruct (Nat.compare pos frontier_pos) eqn:Hcmp.
+        * (* Eq: Hhit is a hit in new_ (Nat.compare Eq is first constructor) *)
+          fold proj in Hhit.
+          assert (Hhit' : map.get (snd (fst (full, new_, old_))) proj = Some tt). {
+            cbn [fst snd]. exact Hhit.
+          }
+          assert (Hfull : map.get (fst (fst (full, new_, old_))) proj = Some tt). {
+            apply (build_tries_frontier_subset q inst f n trie_list (full, new_, old_) proj Hf Hn).
+            exact Hhit'.
+          }
+          cbn [fst] in Hfull.
+          pose proof (build_tries_sound q inst f n clause trie_list (full, new_, old_) proj q_f Hqf Hclause Hf Hn Hfull)
+            as [ args [ v [Hdb Hmatch] ] ].
+          exists args. exists v.
+          exact (conj Hdb Hmatch).
+        * (* Lt: Hhit is a hit in old_ *)
+          fold proj in Hhit.
+          assert (Hhit_old : map.get (snd (full, new_, old_)) proj = Some tt). {
+            cbn [fst snd]. exact Hhit.
+          }
+          assert (Hfull : map.get (fst (fst (full, new_, old_))) proj = Some tt). {
+            apply (build_tries_old_subset q inst f n trie_list (full, new_, old_) proj Hf Hn).
+            exact Hhit_old.
+          }
+          cbn [fst] in Hfull.
+          pose proof (build_tries_sound q inst f n clause trie_list (full, new_, old_) proj q_f Hqf Hclause Hf Hn Hfull)
+            as [ args [ v [Hdb Hmatch] ] ].
+          exists args. exists v.
+          exact (conj Hdb Hmatch).
+        * (* Gt: Hhit is a hit in full *)
+          fold proj in Hhit.
+          assert (Hhit_full : map.get (fst (fst (full, new_, old_))) proj = Some tt). {
+            cbn [fst snd]. exact Hhit.
+          }
+          pose proof (build_tries_sound q inst f n clause trie_list (full, new_, old_) proj q_f Hqf Hclause Hf Hn Hhit_full)
+            as [ args [ v [Hdb Hmatch] ] ].
+          exists args. exists v.
+          exact (conj Hdb Hmatch).
+      + (* map.get trie_list n = None *)
+        destruct (Nat.compare pos frontier_pos) in Hhit;
         cbn [fst] in Hhit;
         rewrite (@map.get_empty _ _ _ (idx_trie_ok unit)) in Hhit;
         discriminate.

--- a/src/Utils/EGraph/Semantics.v
+++ b/src/Utils/EGraph/Semantics.v
@@ -644,6 +644,12 @@ Section WithMap.
   (* build_tries soundness: no false positives in matching               *)
   (* ------------------------------------------------------------------ *)
 
+  (* idx_leb is scoped tightly: only used by the build_tries block below.
+     Keeping it in a sub-section avoids propagating it to all other section-
+     closed lemmas (alloc_sound, union_sound, etc.) which do not need it. *)
+  Section WithIdxLeb.
+  Context (idx_leb : idx -> idx -> bool).
+
   Context (idx_map_plus_ok : @map_plus_ok _ _ idx_map_plus).
 
   (* Helper: get_put on idx_trie with the get-key first, put-key second *)
@@ -657,15 +663,15 @@ Section WithMap.
   Qed.
 
   Lemma build_tries_for_symbol_sound
-    (current_epoch : idx)
+    (current_epoch : idx) (window : nat)
     (q_clauses : idx_map (list nat * nat))
     (tbl : idx_trie (db_entry idx analysis_result))
     (n : idx) (clause : list nat * nat)
     (trie_pair : idx_trie unit * idx_trie unit * idx_trie unit)
     (assignment : list idx) :
     map.get q_clauses n = Some clause ->
-    map.get (build_tries_for_symbol idx Eqb_idx idx_map idx_map_plus idx_trie
-               analysis_result current_epoch q_clauses tbl) n = Some trie_pair ->
+    map.get (build_tries_for_symbol idx Eqb_idx idx_succ idx_leb idx_map idx_map_plus idx_trie
+               analysis_result current_epoch window q_clauses tbl) n = Some trie_pair ->
     map.get (fst (fst trie_pair)) assignment = Some tt ->
     exists args entry,
       map.get tbl args = Some entry
@@ -707,7 +713,7 @@ Section WithMap.
       cbn [fst] in Hfull.
       destruct (match_clause clause k vv) as [ assignment0 | ] eqn:Hmatch.
       { (* Match succeeded: assignment0 was recorded in full *)
-        destruct (eqb epoch current_epoch) eqn:Hepoch.
+        destruct (idx_leb current_epoch (Nat.iter window idx_succ epoch)) eqn:Hepoch.
         - cbn [fst] in Hfull.
           destruct (eqb (assignment0 : list idx) assignment) eqn:Heqasg.
           + pose proof (@eqb_spec (list idx) (list_eqb (A:=idx))
@@ -764,7 +770,7 @@ Section WithMap.
         - exact Hentry. }
   Qed.
 
-  Lemma build_tries_sound (q : rule_set idx symbol symbol_map idx_map)
+  Lemma build_tries_sound (window : nat) (q : rule_set idx symbol symbol_map idx_map)
     (inst : instance)
     (f : symbol) (n : idx) (clause : list nat * nat)
     (clause_tries : idx_map (idx_trie unit * idx_trie unit * idx_trie unit))
@@ -772,8 +778,8 @@ Section WithMap.
     (q_f : idx_map (list nat * nat)) :
     map.get (q.(query_clauses idx symbol symbol_map idx_map)) f = Some q_f ->
     map.get q_f n = Some clause ->
-    map.get (fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
-      idx_map idx_map_plus idx_trie analysis_result q inst)) f = Some clause_tries ->
+    map.get (fst (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
+      idx_map idx_map_plus idx_trie analysis_result window q inst)) f = Some clause_tries ->
     map.get clause_tries n = Some trie_pair ->
     map.get (fst (fst trie_pair)) assignment = Some tt ->
     exists args v,
@@ -788,7 +794,7 @@ Section WithMap.
     - unfold db_map in Htbl.
       rewrite Htbl in Hbt_f.
       injection Hbt_f; intro; subst clause_tries.
-      pose proof (build_tries_for_symbol_sound (inst.(epoch)) q_f tbl n clause trie_pair assignment
+      pose proof (build_tries_for_symbol_sound (inst.(epoch)) window q_f tbl n clause trie_pair assignment
         Hclause Hct_n Hfull) as [ args [ entry [ Hargs Hentry ] ] ].
       exists args. exists entry.(entry_value idx analysis_result).
       split.
@@ -806,11 +812,11 @@ Section WithMap.
   Qed.
 
   Lemma build_tries_for_symbol_frontier_subset
-    (current_epoch : idx) (q_clauses : idx_map (list nat * nat))
+    (current_epoch : idx) (window : nat) (q_clauses : idx_map (list nat * nat))
     (tbl : idx_trie (db_entry idx analysis_result))
     (n : idx) (trie_pair : idx_trie unit * idx_trie unit * idx_trie unit) (assignment : list idx) :
-    map.get (build_tries_for_symbol idx Eqb_idx idx_map idx_map_plus idx_trie
-               analysis_result current_epoch q_clauses tbl) n = Some trie_pair ->
+    map.get (build_tries_for_symbol idx Eqb_idx idx_succ idx_leb idx_map idx_map_plus idx_trie
+               analysis_result current_epoch window q_clauses tbl) n = Some trie_pair ->
     map.get (snd (fst trie_pair)) assignment = Some tt ->
     map.get (fst (fst trie_pair)) assignment = Some tt.
   Proof.
@@ -846,8 +852,8 @@ Section WithMap.
       injection Htp; intro; subst tp.
       destruct tp_old as [ [ full_old new_old ] old_old ].
       destruct (match_clause cl k vv) as [ assignment0 | ] eqn:Hmatch.
-      { destruct (eqb epoch current_epoch) eqn:Hepoch.
-        - (* epoch matches: new' = put new_old assignment0 tt *)
+      { destruct (idx_leb current_epoch (Nat.iter window idx_succ epoch)) eqn:Hepoch.
+        - (* within window: new' = put new_old assignment0 tt *)
           cbn [fst snd] in *.
           destruct (eqb (assignment0 : list idx) assignment) eqn:Heqasg.
           + pose proof (@eqb_spec (list idx) (list_eqb (A:=idx))
@@ -865,7 +871,7 @@ Section WithMap.
             rewrite (get_put_diff_trie unit full_old assignment assignment0 tt
               (fun H => Hbs (eq_sym H))).
             exact Hfull_old.
-        - (* epoch doesn't match: new' = new_old unchanged *)
+        - (* outside window: new' = new_old unchanged *)
           cbn [fst snd] in *.
           pose proof (IH (full_old, new_old, old_old) eq_refl) as HIH.
           cbn [fst snd] in HIH.
@@ -886,13 +892,13 @@ Section WithMap.
         exact (IH (full_old, new_old, old_old) eq_refl Hfront). }
   Qed.
 
-  Lemma build_tries_frontier_subset (q : rule_set idx symbol symbol_map idx_map)
+  Lemma build_tries_frontier_subset (window : nat) (q : rule_set idx symbol symbol_map idx_map)
     (inst : instance)
     (f : symbol) (n : idx)
     (clause_tries : idx_map (idx_trie unit * idx_trie unit * idx_trie unit))
     (trie_pair : idx_trie unit * idx_trie unit * idx_trie unit) (assignment : list idx) :
-    map.get (fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
-      idx_map idx_map_plus idx_trie analysis_result q inst)) f = Some clause_tries ->
+    map.get (fst (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
+      idx_map idx_map_plus idx_trie analysis_result window q inst)) f = Some clause_tries ->
     map.get clause_tries n = Some trie_pair ->
     map.get (snd (fst trie_pair)) assignment = Some tt ->
     map.get (fst (fst trie_pair)) assignment = Some tt.
@@ -905,7 +911,7 @@ Section WithMap.
       + unfold db_map in Htbl.
         rewrite Htbl in Hbt_f.
         injection Hbt_f; intro; subst clause_tries.
-        apply (build_tries_for_symbol_frontier_subset (inst.(epoch)) q_f tbl n trie_pair assignment
+        apply (build_tries_for_symbol_frontier_subset (inst.(epoch)) window q_f tbl n trie_pair assignment
           Hct_n Hfront).
       + unfold db_map in Htbl.
         rewrite Htbl in Hbt_f.
@@ -914,7 +920,7 @@ Section WithMap.
   Qed.
 
   Lemma clause_ptr_atom_in_db
-    (q : rule_set idx symbol symbol_map idx_map) (inst : instance)
+    (window : nat) (q : rule_set idx symbol symbol_map idx_map) (inst : instance)
     (query_vars : list idx) (frontier_n : idx)
     (f : symbol) (n : idx) (clause_vars : list idx)
     (q_f : idx_map (list nat * nat)) (clause : list nat * nat)
@@ -923,8 +929,8 @@ Section WithMap.
     map.get q_f n = Some clause ->
     map.get (fst (trie_of_clause idx Eqb_idx symbol symbol_map idx_map idx_trie
                     query_vars
-                    (fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
-                            idx_map idx_map_plus idx_trie analysis_result q inst))
+                    (fst (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
+                            idx_map idx_map_plus idx_trie analysis_result window q inst))
                     frontier_n (Build_erule_query_ptr idx symbol f n clause_vars)))
             (map fst (filter snd (combine sigma
                (variable_flags idx Eqb_idx query_vars clause_vars))))
@@ -939,8 +945,8 @@ Section WithMap.
     unfold trie_of_clause in Hhit.
     cbn [fst snd] in Hhit.
     set (proj := map fst (filter snd (combine sigma (variable_flags idx Eqb_idx query_vars clause_vars)))).
-    set (db_tries := fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
-                            idx_map idx_map_plus idx_trie analysis_result q inst)).
+    set (db_tries := fst (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
+                            idx_map idx_map_plus idx_trie analysis_result window q inst)).
     destruct (map.get db_tries f) as [ trie_list | ] eqn:Hf.
     - (* Some trie_list case *)
       fold db_tries in Hhit.
@@ -953,17 +959,17 @@ Section WithMap.
         * (* eqb n frontier_n = true, new_ case *)
           fold proj in Hhit.
           assert (Hfull : map.get (fst (fst (total, new_, old_))) proj = Some tt). {
-            apply (build_tries_frontier_subset q inst f n trie_list (total, new_, old_) proj Hf Hn).
+            apply (build_tries_frontier_subset window q inst f n trie_list (total, new_, old_) proj Hf Hn).
             exact Hhit.
           }
           cbn [fst] in Hfull.
-          pose proof (build_tries_sound q inst f n clause trie_list (total, new_, old_) proj q_f Hqf Hclause Hf Hn Hfull)
+          pose proof (build_tries_sound window q inst f n clause trie_list (total, new_, old_) proj q_f Hqf Hclause Hf Hn Hfull)
             as [ args [ v [Hdb Hmatch] ] ].
           exists args. exists v.
           exact (conj Hdb Hmatch).
         * (* eqb n frontier_n = false, total case *)
           fold proj in Hhit.
-          pose proof (build_tries_sound q inst f n clause trie_list (total, new_, old_) proj q_f Hqf Hclause Hf Hn Hhit)
+          pose proof (build_tries_sound window q inst f n clause trie_list (total, new_, old_) proj q_f Hqf Hclause Hf Hn Hhit)
             as [ args [ v [Hdb Hmatch] ] ].
           exists args. exists v.
           exact (conj Hdb Hmatch).
@@ -984,11 +990,11 @@ Section WithMap.
      [old] (= snd) implies a hit in [full] (= fst (fst)).  Needed for the proper
      semi-naive 3-way selection where clauses before the frontier use [old]. *)
   Lemma build_tries_for_symbol_old_subset
-    (current_epoch : idx) (q_clauses : idx_map (list nat * nat))
+    (current_epoch : idx) (window : nat) (q_clauses : idx_map (list nat * nat))
     (tbl : idx_trie (db_entry idx analysis_result))
     (n : idx) (trie_pair : idx_trie unit * idx_trie unit * idx_trie unit) (assignment : list idx) :
-    map.get (build_tries_for_symbol idx Eqb_idx idx_map idx_map_plus idx_trie
-               analysis_result current_epoch q_clauses tbl) n = Some trie_pair ->
+    map.get (build_tries_for_symbol idx Eqb_idx idx_succ idx_leb idx_map idx_map_plus idx_trie
+               analysis_result current_epoch window q_clauses tbl) n = Some trie_pair ->
     map.get (snd trie_pair) assignment = Some tt ->
     map.get (fst (fst trie_pair)) assignment = Some tt.
   Proof.
@@ -1024,8 +1030,8 @@ Section WithMap.
       injection Htp; intro; subst tp.
       destruct tp_old as [ [ full_old new_old ] old_old ].
       destruct (match_clause cl k vv) as [ assignment0 | ] eqn:Hmatch.
-      { destruct (eqb epoch current_epoch) eqn:Hepoch.
-        - (* epoch matches: old' = old_old (unchanged), full' = put full_old asg0 *)
+      { destruct (idx_leb current_epoch (Nat.iter window idx_succ epoch)) eqn:Hepoch.
+        - (* within window: old' = old_old (unchanged), full' = put full_old asg0 *)
           cbn [fst snd] in *.
           (* Hfront : map.get old_old assignment = Some tt *)
           pose proof (IH (full_old, new_old, old_old) eq_refl) as HIH.
@@ -1042,7 +1048,7 @@ Section WithMap.
             rewrite (get_put_diff_trie unit full_old assignment assignment0 tt
               (fun H => Hbs (eq_sym H))).
             exact Hfull_old.
-        - (* epoch doesn't match: old' = put old_old asg0, full' = put full_old asg0 *)
+        - (* outside window: old' = put old_old asg0, full' = put full_old asg0 *)
           cbn [fst snd] in *.
           destruct (eqb (assignment0 : list idx) assignment) eqn:Heqasg.
           + pose proof (@eqb_spec (list idx) (list_eqb (A:=idx))
@@ -1065,13 +1071,13 @@ Section WithMap.
         exact (IH (full_old, new_old, old_old) eq_refl Hfront). }
   Qed.
 
-  Lemma build_tries_old_subset (q : rule_set idx symbol symbol_map idx_map)
+  Lemma build_tries_old_subset (window : nat) (q : rule_set idx symbol symbol_map idx_map)
     (inst : instance)
     (f : symbol) (n : idx)
     (clause_tries : idx_map (idx_trie unit * idx_trie unit * idx_trie unit))
     (trie_pair : idx_trie unit * idx_trie unit * idx_trie unit) (assignment : list idx) :
-    map.get (fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
-      idx_map idx_map_plus idx_trie analysis_result q inst)) f = Some clause_tries ->
+    map.get (fst (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
+      idx_map idx_map_plus idx_trie analysis_result window q inst)) f = Some clause_tries ->
     map.get clause_tries n = Some trie_pair ->
     map.get (snd trie_pair) assignment = Some tt ->
     map.get (fst (fst trie_pair)) assignment = Some tt.
@@ -1084,7 +1090,7 @@ Section WithMap.
       + unfold db_map in Htbl.
         rewrite Htbl in Hbt_f.
         injection Hbt_f; intro; subst clause_tries.
-        apply (build_tries_for_symbol_old_subset (inst.(epoch)) q_f tbl n trie_pair assignment
+        apply (build_tries_for_symbol_old_subset (inst.(epoch)) window q_f tbl n trie_pair assignment
           Hct_n Hfront).
       + unfold db_map in Htbl.
         rewrite Htbl in Hbt_f.
@@ -1097,7 +1103,7 @@ Section WithMap.
      (old if pos<frontier_pos, new if =, full if >) reduces to a db atom via the
      subset lemmas + build_tries_sound. *)
   Lemma clause_ptr_atom_in_db_sn
-    (q : rule_set idx symbol symbol_map idx_map) (inst : instance)
+    (window : nat) (q : rule_set idx symbol symbol_map idx_map) (inst : instance)
     (query_vars : list idx) (frontier_pos pos : nat)
     (f : symbol) (n : idx) (clause_vars : list idx)
     (q_f : idx_map (list nat * nat)) (clause : list nat * nat)
@@ -1106,8 +1112,8 @@ Section WithMap.
     map.get q_f n = Some clause ->
     map.get (fst (trie_of_clause_sn idx Eqb_idx symbol symbol_map idx_map idx_trie
                     query_vars
-                    (fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
-                            idx_map idx_map_plus idx_trie analysis_result q inst))
+                    (fst (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
+                            idx_map idx_map_plus idx_trie analysis_result window q inst))
                     frontier_pos pos (Build_erule_query_ptr idx symbol f n clause_vars)))
             (map fst (filter snd (combine sigma
                (variable_flags idx Eqb_idx query_vars clause_vars))))
@@ -1122,8 +1128,8 @@ Section WithMap.
     unfold trie_of_clause_sn in Hhit.
     cbn [fst snd] in Hhit.
     set (proj := map fst (filter snd (combine sigma (variable_flags idx Eqb_idx query_vars clause_vars)))).
-    set (db_tries := fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
-                            idx_map idx_map_plus idx_trie analysis_result q inst)).
+    set (db_tries := fst (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
+                            idx_map idx_map_plus idx_trie analysis_result window q inst)).
     destruct (map.get db_tries f) as [ trie_list | ] eqn:Hf.
     - (* Some trie_list case *)
       fold db_tries in Hhit.
@@ -1139,11 +1145,11 @@ Section WithMap.
             cbn [fst snd]. exact Hhit.
           }
           assert (Hfull : map.get (fst (fst (full, new_, old_))) proj = Some tt). {
-            apply (build_tries_frontier_subset q inst f n trie_list (full, new_, old_) proj Hf Hn).
+            apply (build_tries_frontier_subset window q inst f n trie_list (full, new_, old_) proj Hf Hn).
             exact Hhit'.
           }
           cbn [fst] in Hfull.
-          pose proof (build_tries_sound q inst f n clause trie_list (full, new_, old_) proj q_f Hqf Hclause Hf Hn Hfull)
+          pose proof (build_tries_sound window q inst f n clause trie_list (full, new_, old_) proj q_f Hqf Hclause Hf Hn Hfull)
             as [ args [ v [Hdb Hmatch] ] ].
           exists args. exists v.
           exact (conj Hdb Hmatch).
@@ -1153,11 +1159,11 @@ Section WithMap.
             cbn [fst snd]. exact Hhit.
           }
           assert (Hfull : map.get (fst (fst (full, new_, old_))) proj = Some tt). {
-            apply (build_tries_old_subset q inst f n trie_list (full, new_, old_) proj Hf Hn).
+            apply (build_tries_old_subset window q inst f n trie_list (full, new_, old_) proj Hf Hn).
             exact Hhit_old.
           }
           cbn [fst] in Hfull.
-          pose proof (build_tries_sound q inst f n clause trie_list (full, new_, old_) proj q_f Hqf Hclause Hf Hn Hfull)
+          pose proof (build_tries_sound window q inst f n clause trie_list (full, new_, old_) proj q_f Hqf Hclause Hf Hn Hfull)
             as [ args [ v [Hdb Hmatch] ] ].
           exists args. exists v.
           exact (conj Hdb Hmatch).
@@ -1166,7 +1172,7 @@ Section WithMap.
           assert (Hhit_full : map.get (fst (fst (full, new_, old_))) proj = Some tt). {
             cbn [fst snd]. exact Hhit.
           }
-          pose proof (build_tries_sound q inst f n clause trie_list (full, new_, old_) proj q_f Hqf Hclause Hf Hn Hhit_full)
+          pose proof (build_tries_sound window q inst f n clause trie_list (full, new_, old_) proj q_f Hqf Hclause Hf Hn Hhit_full)
             as [ args [ v [Hdb Hmatch] ] ].
           exists args. exists v.
           exact (conj Hdb Hmatch).
@@ -1182,6 +1188,8 @@ Section WithMap.
       rewrite (@map.get_empty _ _ _ (idx_trie_ok unit)) in Hhit.
       discriminate.
   Qed.
+
+  End WithIdxLeb.
 
   Lemma project_filter_variable_flags (P : idx -> bool) (query_vars sigma : list idx) (d : idx) :
     List.NoDup query_vars ->
@@ -1461,12 +1469,6 @@ Section WithMap.
     split; [exact Hok | exists map.empty; exact Hsound].
   Qed.
   
-  Notation saturate_until' := (saturate_until' idx_succ idx_zero (spaced_list_intersect)).
-  Notation saturate_until := (saturate_until idx_succ idx_zero spaced_list_intersect).
-
-  Notation run1iter :=
-    (run1iter idx Eqb_idx idx_succ idx_zero symbol Eqb_symbol symbol_map symbol_map_plus
-       idx_map idx_map_plus idx_trie spaced_list_intersect).
   (*
   Notation rebuild := (rebuild idx Eqb_idx symbol Eqb_symbol symbol_map idx_map idx_trie).
   *)
@@ -1660,7 +1662,7 @@ Section WithMap.
     1:eapply all2_refl.
     all: apply reachable_rel_Reflexive.
   Qed.
-  
+
   Lemma atom_rel_sym equiv : Symmetric (atom_rel equiv).
   Proof using.
     clear lt idx_succ idx_zero.
@@ -1988,7 +1990,7 @@ Section WithMap.
       eq_sound_for_model m i y z ->
       eq_sound_for_model m i x z.
   Proof using H0.
-    clear lt idx_succ.
+    clear lt idx_succ idx_zero.
     unfold  eq_sound_for_model, Is_Some_satisfying.
     repeat case_match; basic_goal_prep; auto.
     all: try tauto.

--- a/src/Utils/EGraph/SemanticsProcessErule.v
+++ b/src/Utils/EGraph/SemanticsProcessErule.v
@@ -13,6 +13,7 @@ Section Slice.
   Context
     {idx : Type} {Eqb_idx : Eqb idx} {Eqb_idx_ok : Eqb_ok Eqb_idx}
     {lt : idx -> idx -> Prop} {idx_succ : idx -> idx} {idx_zero : WithDefault idx}
+    {idx_leb : idx -> idx -> bool}
     {symbol : Type} {Eqb_symbol : Eqb symbol} {Eqb_symbol_ok : Eqb_ok Eqb_symbol}
     {symbol_map : forall A, map.map symbol A} {symbol_map_plus : map_plus symbol_map}
     {symbol_map_plus_ok : @map_plus_ok _ _ symbol_map_plus} {symbol_map_ok : forall A, map.ok (symbol_map A)}
@@ -21,7 +22,8 @@ Section Slice.
     {analysis_result : Type} {idx_map_plus_ok : @map_plus_ok _ _ idx_map_plus}
     {spaced_list_intersect
       : forall B, WithDefault B -> (B -> B -> B) -> ne_list (map.rep (map:=idx_trie B) * list bool) -> map.rep (map:=idx_trie B)}
-    {H : analysis idx symbol analysis_result} {m : model symbol} {Hm : model_ok symbol m}.
+    {H : analysis idx symbol analysis_result} {m : model symbol} {Hm : model_ok symbol m}
+    (window : nat).
   Existing Instance idx_zero.
   Notation instance := (instance idx symbol symbol_map idx_map idx_trie analysis_result).
   Notation egraph_ok := (egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result).
@@ -30,8 +32,8 @@ Section Slice.
   Notation atom_interpretation := (atom_interpretation idx symbol symbol_map idx_map idx_trie analysis_result).
   Notation idx_interpretation_wf := (idx_interpretation_wf idx symbol symbol_map idx_map idx_trie analysis_result).
   Notation interpretation_exact := (interpretation_exact idx symbol symbol_map idx_map idx_trie analysis_result).
-  Notation clause_ptr_atom_in_db := (clause_ptr_atom_in_db idx Eqb_idx Eqb_idx_ok symbol symbol_map symbol_map_plus symbol_map_plus_ok idx_map idx_map_plus idx_trie idx_trie_ok analysis_result idx_map_plus_ok).
-  Notation clause_ptr_atom_in_db_sn := (clause_ptr_atom_in_db_sn idx Eqb_idx Eqb_idx_ok symbol symbol_map symbol_map_plus symbol_map_plus_ok idx_map idx_map_plus idx_trie idx_trie_ok analysis_result idx_map_plus_ok).
+  Notation clause_ptr_atom_in_db := (clause_ptr_atom_in_db idx Eqb_idx Eqb_idx_ok idx_succ symbol symbol_map symbol_map_plus symbol_map_plus_ok idx_map idx_map_plus idx_trie idx_trie_ok analysis_result idx_leb idx_map_plus_ok window).
+  Notation clause_ptr_atom_in_db_sn := (clause_ptr_atom_in_db_sn idx Eqb_idx Eqb_idx_ok idx_succ symbol symbol_map symbol_map_plus symbol_map_plus_ok idx_map idx_map_plus idx_trie idx_trie_ok analysis_result idx_leb idx_map_plus_ok window).
   Notation match_clause_correct := (match_clause_correct idx Eqb_idx Eqb_idx_ok).
   Notation project_filter_variable_flags := (project_filter_variable_flags idx Eqb_idx Eqb_idx_ok).
   Notation get_of_list_combine := (get_of_list_combine idx Eqb_idx Eqb_idx_ok idx_map idx_map_ok).
@@ -72,8 +74,8 @@ Section Slice.
     cv < List.length clause_vars ->
     map.get (fst (trie_of_clause idx Eqb_idx symbol symbol_map idx_map idx_trie
                     query_vars
-                    (fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
-                            idx_map idx_map_plus idx_trie analysis_result q inst))
+                    (fst (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
+                            idx_map idx_map_plus idx_trie analysis_result window q inst))
                     frontier_n (Build_erule_query_ptr idx symbol f n clause_vars)))
             (map fst (filter snd (combine sigma
                (variable_flags idx Eqb_idx query_vars clause_vars))))
@@ -158,8 +160,8 @@ Section Slice.
     cv < List.length clause_vars ->
     map.get (fst (trie_of_clause_sn idx Eqb_idx symbol symbol_map idx_map idx_trie
                     query_vars
-                    (fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
-                            idx_map idx_map_plus idx_trie analysis_result q inst))
+                    (fst (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
+                            idx_map idx_map_plus idx_trie analysis_result window q inst))
                     frontier_pos pos (Build_erule_query_ptr idx symbol f n clause_vars)))
             (map fst (filter snd (combine sigma
                (variable_flags idx Eqb_idx query_vars clause_vars))))
@@ -251,8 +253,8 @@ Section Slice.
           (uncurry cons (query_clause_ptrs idx symbol r)) ->
        map.get (fst (trie_of_clause idx Eqb_idx symbol symbol_map idx_map idx_trie
                        (query_vars idx symbol r)
-                       (fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
-                               idx_map idx_map_plus idx_trie analysis_result q inst))
+                       (fst (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
+                               idx_map idx_map_plus idx_trie analysis_result window q inst))
                        frontier_n (Build_erule_query_ptr idx symbol fsym nptr cvars)))
                (map fst (filter snd (combine sigma
                   (variable_flags idx Eqb_idx (query_vars idx symbol r) cvars))))
@@ -303,8 +305,8 @@ Section Slice.
          = Some (Build_erule_query_ptr idx symbol fsym nptr cvars) ->
        map.get (fst (trie_of_clause_sn idx Eqb_idx symbol symbol_map idx_map idx_trie
                        (query_vars idx symbol r)
-                       (fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
-                               idx_map idx_map_plus idx_trie analysis_result q inst))
+                       (fst (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
+                               idx_map idx_map_plus idx_trie analysis_result window q inst))
                        frontier_pos pos (Build_erule_query_ptr idx symbol fsym nptr cvars)))
                (map fst (filter snd (combine sigma
                   (variable_flags idx Eqb_idx (query_vars idx symbol r) cvars))))
@@ -408,8 +410,8 @@ Section Slice.
     (Hlti : Asymmetric lt) (Hlts : forall x, lt x (idx_succ x)) (Hltt : Transitive lt)
     (i_snap : idx_map (domain symbol m)) (inst : instance)
     (q : rule_set idx symbol symbol_map idx_map) (r : erule idx symbol) :
-    let db_tries := fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
-                           idx_map idx_map_plus idx_trie analysis_result q inst) in
+    let db_tries := fst (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
+                           idx_map idx_map_plus idx_trie analysis_result window q inst) in
     egraph_sound_for_interpretation i_snap inst ->
     List.NoDup (query_vars idx symbol r) ->
     List.NoDup (write_vars idx symbol r) ->
@@ -533,8 +535,8 @@ Section Slice.
     (i_snap i_start : idx_map (domain symbol m)) (inst : instance)
     (q : rule_set idx symbol symbol_map idx_map) (r : erule idx symbol)
     (frontier_n : idx) (e_start : instance) :
-    let db_tries := fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
-                           idx_map idx_map_plus idx_trie analysis_result q inst) in
+    let db_tries := fst (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
+                           idx_map idx_map_plus idx_trie analysis_result window q inst) in
     let tries := ne_map (trie_of_clause idx Eqb_idx symbol symbol_map idx_map idx_trie
                            (query_vars idx symbol r) db_tries frontier_n)
                         (query_clause_ptrs idx symbol r) in
@@ -675,8 +677,8 @@ Section Slice.
     (i_snap i_start : idx_map (domain symbol m)) (inst : instance)
     (q : rule_set idx symbol symbol_map idx_map) (r : erule idx symbol)
     (frontier_pos : nat) (e_start : instance) :
-    let db_tries := fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
-                           idx_map idx_map_plus idx_trie analysis_result q inst) in
+    let db_tries := fst (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
+                           idx_map idx_map_plus idx_trie analysis_result window q inst) in
     let tries := ne_map_idx (fun pos ptr =>
                                trie_of_clause_sn idx Eqb_idx symbol symbol_map idx_map idx_trie
                                  (query_vars idx symbol r) db_tries frontier_pos pos ptr)
@@ -820,6 +822,7 @@ End Slice.
 Lemma process_erule_sound
   (idx : Type) (Eqb_idx : Eqb idx) (Eqb_idx_ok : Eqb_ok Eqb_idx)
   (lt : idx -> idx -> Prop) (idx_succ : idx -> idx) (idx_zero : WithDefault idx)
+  (idx_leb : idx -> idx -> bool)
   (symbol : Type) (Eqb_symbol : Eqb symbol) (Eqb_symbol_ok : Eqb_ok Eqb_symbol)
   (symbol_map : forall A, map.map symbol A) (symbol_map_plus : map_plus symbol_map)
   (symbol_map_plus_ok : @map_plus_ok _ _ symbol_map_plus) (symbol_map_ok : forall A, map.ok (symbol_map A))
@@ -830,12 +833,13 @@ Lemma process_erule_sound
     : forall B, WithDefault B -> (B -> B -> B) -> ne_list (map.rep (map:=idx_trie B) * list bool) -> map.rep (map:=idx_trie B))
   (H : analysis idx symbol analysis_result) (m : model symbol) (Hm : model_ok symbol m)
   (Hlti : Asymmetric lt) (Hlts : forall x, lt x (idx_succ x)) (Hltt : Transitive lt)
+  (window : nat)
   (i_snap i_start : idx_map (domain symbol m))
   (inst : instance idx symbol symbol_map idx_map idx_trie analysis_result)
   (q : rule_set idx symbol symbol_map idx_map) (r : erule idx symbol)
   (e_start : instance idx symbol symbol_map idx_map idx_trie analysis_result) :
-  let db_tries := fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
-                         idx_map idx_map_plus idx_trie analysis_result q inst) in
+  let db_tries := fst (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
+                         idx_map idx_map_plus idx_trie analysis_result window q inst) in
   egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i_snap inst ->
   egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result e_start ->
   egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i_start e_start ->
@@ -915,7 +919,7 @@ Proof.
     - cbn [list_Miter]. split; [exact Hok_cur|].
       exists icur. split; [exact Hext_cur | exact Hsnd_cur].
     - cbn [list_Miter].
-      pose proof (process_erule'_sn_sound Hlti Hlts Hltt i_snap icur inst q r p e_cur
+      pose proof (process_erule'_sn_sound window Hlti Hlts Hltt i_snap icur inst q r p e_cur
                     Hsnd_inst Hok_cur Hsnd_cur Hext_cur Hnd_qv Hnd_wv Hrule
                     Hwf Hcov Hdisj HcovC HcovU (Hlen_sig p) (Hsli p)) as Hstep.
       cbv zeta in Hstep.

--- a/src/Utils/EGraph/SemanticsProcessErule.v
+++ b/src/Utils/EGraph/SemanticsProcessErule.v
@@ -31,6 +31,7 @@ Section Slice.
   Notation idx_interpretation_wf := (idx_interpretation_wf idx symbol symbol_map idx_map idx_trie analysis_result).
   Notation interpretation_exact := (interpretation_exact idx symbol symbol_map idx_map idx_trie analysis_result).
   Notation clause_ptr_atom_in_db := (clause_ptr_atom_in_db idx Eqb_idx Eqb_idx_ok symbol symbol_map symbol_map_plus symbol_map_plus_ok idx_map idx_map_plus idx_trie idx_trie_ok analysis_result idx_map_plus_ok).
+  Notation clause_ptr_atom_in_db_sn := (clause_ptr_atom_in_db_sn idx Eqb_idx Eqb_idx_ok symbol symbol_map symbol_map_plus symbol_map_plus_ok idx_map idx_map_plus idx_trie idx_trie_ok analysis_result idx_map_plus_ok).
   Notation match_clause_correct := (match_clause_correct idx Eqb_idx Eqb_idx_ok).
   Notation project_filter_variable_flags := (project_filter_variable_flags idx Eqb_idx Eqb_idx_ok).
   Notation get_of_list_combine := (get_of_list_combine idx Eqb_idx Eqb_idx_ok idx_map idx_map_ok).
@@ -83,6 +84,92 @@ Section Slice.
   Proof.
     intros Hsnd Hnd Hlen Ha_q Hqf Hclause Hcvars Hbound_args Hbound_cv Hhit.
     pose proof (clause_ptr_atom_in_db q inst query_vars frontier_n f n clause_vars q_f (cargs,cv) sigma Hqf Hclause Hhit) as Hcp.
+    destruct Hcp as [ args_db [ v_db [ Hdb Hmatch ] ] ].
+    set (proj := map fst (filter snd (combine sigma (variable_flags idx Eqb_idx query_vars clause_vars)))) in *.
+    pose proof (atom_interpretation m i inst Hsnd (Build_atom f args_db v_db) Hdb) as Hdb_snd.
+    unfold atom_sound_for_model in Hdb_snd.
+    cbn [atom_args atom_ret atom_fn] in Hdb_snd.
+    destruct (list_Mmap (map.get i) args_db) as [doms|] eqn:Hdoms; cbn [Is_Some_satisfying] in Hdb_snd; [ | contradiction ].
+    destruct (map.get i v_db) as [out|] eqn:Hout; cbn [Is_Some_satisfying] in Hdb_snd; [ | contradiction ].
+    pose proof (match_clause_correct idx_zero cargs cv args_db v_db proj Hmatch) as Hmc.
+    cbn [map] in Hmc.
+    injection Hmc as Hcv_eq Hcargs_eq.
+    assert (Hproj : proj = map (fun cvv => named_list_lookup idx_zero (combine query_vars sigma) cvv) clause_vars)
+      by (unfold proj; rewrite Hcvars; apply (project_filter_variable_flags P query_vars sigma idx_zero Hnd (eq_sym Hlen))).
+    assert (Hincl : incl clause_vars query_vars)
+      by (intros x Hx; rewrite Hcvars in Hx; apply filter_In in Hx; destruct Hx as [Hx _]; exact Hx).
+    assert (Hkey : forall t, t < length clause_vars ->
+      map.get a_q (nth t clause_vars idx_zero)
+      = map.get i (named_list_lookup idx_zero (assign_sub proj) t))
+      by (intros t Ht; rewrite Ha_q;
+          rewrite (get_of_list_combine idx idx_zero query_vars sigma (nth t clause_vars idx_zero) Hnd Hlen)
+            by (apply Hincl; apply nth_In; exact Ht);
+          f_equal;
+          rewrite named_list_lookup_assign_sub by (rewrite Hproj, length_map; exact Ht);
+          rewrite Hproj; rewrite nth_error_map; rewrite (nth_error_nth' clause_vars idx_zero Ht);
+          cbn [option_map]; reflexivity).
+    assert (Hgen : forall cs, (forall k, In k cs -> k < length clause_vars) ->
+       list_Mmap (map.get a_q) (map (fun k => nth k clause_vars idx_zero) cs)
+       = list_Mmap (map.get i) (map (fun x => named_list_lookup idx_zero (assign_sub proj) x) cs))
+      by (intros cs; induction cs as [|c cs' IH]; intros Hb;
+          [ reflexivity
+          | cbn [list_Mmap map];
+            rewrite (Hkey c (Hb c (or_introl eq_refl)));
+            rewrite (IH (fun k Hk => Hb k (or_intror Hk)));
+            reflexivity ]).
+    unfold atom_sound_for_model.
+    cbn [atom_args atom_ret atom_fn].
+    rewrite (Hgen cargs Hbound_args).
+    setoid_rewrite Hcargs_eq.
+    setoid_rewrite Hdoms.
+    cbn [Is_Some_satisfying].
+    setoid_rewrite (Hkey cv Hbound_cv).
+    setoid_rewrite Hcv_eq.
+    setoid_rewrite Hout.
+    cbn [Is_Some_satisfying].
+    exact Hdb_snd.
+  Qed.
+
+  (* Proper semi-naive variant of query_clause_ptr_sound: the clause trie is
+     selected by POSITION [pos] against the frontier position [frontier_pos]
+     (old/new/full via Nat.compare).  A hit in the selected trie still reduces
+     to a db atom (clause_ptr_atom_in_db_sn), so the reconstructed query atom is
+     sound regardless of which of old/new/full was selected. *)
+  Lemma query_clause_ptr_sound_sn
+    (i : idx_map (domain symbol m))
+    (q : rule_set idx symbol symbol_map idx_map) (inst : instance)
+    (query_vars : list idx) (frontier_pos pos : nat) (sigma : list idx)
+    (a_q : idx_map (domain symbol m))
+    (f : symbol) (n : idx) (clause_vars : list idx)
+    (q_f : idx_map (list nat * nat)) (cargs : list nat) (cv : nat)
+    (P : idx -> bool) :
+    egraph_sound_for_interpretation i inst ->
+    List.NoDup query_vars ->
+    List.length query_vars = List.length sigma ->
+    (forall x, map.get a_q x
+       = match map.get (map.of_list (combine query_vars sigma)) x with
+         | Some v => map.get i v
+         | None => None
+         end) ->
+    map.get (query_clauses idx symbol symbol_map idx_map q) f = Some q_f ->
+    map.get q_f n = Some (cargs, cv) ->
+    clause_vars = filter P query_vars ->
+    (forall t, In t cargs -> t < List.length clause_vars) ->
+    cv < List.length clause_vars ->
+    map.get (fst (trie_of_clause_sn idx Eqb_idx symbol symbol_map idx_map idx_trie
+                    query_vars
+                    (fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
+                            idx_map idx_map_plus idx_trie analysis_result q inst))
+                    frontier_pos pos (Build_erule_query_ptr idx symbol f n clause_vars)))
+            (map fst (filter snd (combine sigma
+               (variable_flags idx Eqb_idx query_vars clause_vars))))
+      = Some tt ->
+    atom_sound_for_model m a_q
+      (Build_atom f (map (fun k => nth k clause_vars idx_zero) cargs)
+                    (nth cv clause_vars idx_zero)).
+  Proof.
+    intros Hsnd Hnd Hlen Ha_q Hqf Hclause Hcvars Hbound_args Hbound_cv Hhit.
+    pose proof (clause_ptr_atom_in_db_sn q inst query_vars frontier_pos pos f n clause_vars q_f (cargs,cv) sigma Hqf Hclause Hhit) as Hcp.
     destruct Hcp as [ args_db [ v_db [ Hdb Hmatch ] ] ].
     set (proj := map fst (filter snd (combine sigma (variable_flags idx Eqb_idx query_vars clause_vars)))) in *.
     pose proof (atom_interpretation m i inst Hsnd (Build_atom f args_db v_db) Hdb) as Hdb_snd.
@@ -182,6 +269,59 @@ Section Slice.
     rewrite Hqf, Hclause.
     apply (query_clause_ptr_sound i q inst (query_vars idx symbol r) frontier_n sigma a_q fsym nptr cvars q_f cargs cv Pf Hsnd Hnd Hlen Ha_q Hqf Hclause Hcvars Hba Hbcv).
     exact (Hsli fsym nptr cvars Hptr).
+  Qed.
+
+  (* Proper semi-naive variant of query_atoms_sound: the per-clause trie hit
+     [Hsli] is keyed by clause POSITION (via nth_error) against the frontier
+     position [frontier_pos].  Each query atom corresponds to some ptr at some
+     position; recover that position by In_nth_error and apply the sn clause
+     soundness lemma. *)
+  Lemma query_atoms_sound_sn
+    (i : idx_map (domain symbol m))
+    (q : rule_set idx symbol symbol_map idx_map) (inst : instance)
+    (r : erule idx symbol) (frontier_pos : nat) (sigma : list idx)
+    (a_q : idx_map (domain symbol m)) :
+    egraph_sound_for_interpretation i inst ->
+    List.NoDup (query_vars idx symbol r) ->
+    List.length (query_vars idx symbol r) = List.length sigma ->
+    (forall x, map.get a_q x
+       = match map.get (map.of_list (combine (query_vars idx symbol r) sigma)) x with
+         | Some v => map.get i v
+         | None => None
+         end) ->
+    (forall fsym nptr cvars,
+       In (Build_erule_query_ptr idx symbol fsym nptr cvars)
+          (uncurry cons (query_clause_ptrs idx symbol r)) ->
+       exists q_f cargs cv (Pf : idx -> bool),
+         map.get (query_clauses idx symbol symbol_map idx_map q) fsym = Some q_f
+         /\ map.get q_f nptr = Some (cargs, cv)
+         /\ cvars = filter Pf (query_vars idx symbol r)
+         /\ (forall t, In t cargs -> t < List.length cvars)
+         /\ cv < List.length cvars) ->
+    (forall pos fsym nptr cvars,
+       nth_error (uncurry cons (query_clause_ptrs idx symbol r)) pos
+         = Some (Build_erule_query_ptr idx symbol fsym nptr cvars) ->
+       map.get (fst (trie_of_clause_sn idx Eqb_idx symbol symbol_map idx_map idx_trie
+                       (query_vars idx symbol r)
+                       (fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
+                               idx_map idx_map_plus idx_trie analysis_result q inst))
+                       frontier_pos pos (Build_erule_query_ptr idx symbol fsym nptr cvars)))
+               (map fst (filter snd (combine sigma
+                  (variable_flags idx Eqb_idx (query_vars idx symbol r) cvars))))
+       = Some tt) ->
+    all (atom_sound_for_model m a_q)
+        (query_atoms idx idx_zero symbol symbol_map idx_map (query_clauses idx symbol symbol_map idx_map q) r).
+  Proof.
+    intros Hsnd Hnd Hlen Ha_q Hwf Hsli.
+    unfold query_atoms.
+    apply all_map_in.
+    intros ptr Hptr.
+    destruct ptr as [fsym nptr cvars].
+    destruct (Hwf fsym nptr cvars Hptr) as (q_f & cargs & cv & Pf & Hqf & Hclause & Hcvars & Hba & Hbcv).
+    rewrite Hqf, Hclause.
+    destruct (In_nth_error _ _ Hptr) as [pos Hnth].
+    apply (query_clause_ptr_sound_sn i q inst (query_vars idx symbol r) frontier_pos pos sigma a_q fsym nptr cvars q_f cargs cv Pf Hsnd Hnd Hlen Ha_q Hqf Hclause Hcvars Hba Hbcv).
+    exact (Hsli pos fsym nptr cvars Hnth).
   Qed.
 
   (* From query-atom soundness plus query-variable coverage, [a_q] assigns a
@@ -524,6 +664,151 @@ Section Slice.
     apply (Hloop asn Hlen_sig Hsli e_start i_start Hok_start Hsnd_start Hext_start).
   Qed.
 
+  (* Proper semi-naive soundness for one frontier POSITION of a single erule:
+     running exec_write over the intersection keys of the position-indexed tries
+     (OLD prefix / NEW pivot / TOTAL suffix, [trie_of_clause_sn frontier_pos])
+     preserves egraph_ok and extends the interpretation preserving soundness.
+     Mirror of process_erule'_sound; the only difference is the position-keyed
+     clause selection, threaded through query_atoms_sound_sn. *)
+  Lemma process_erule'_sn_sound
+    (Hlti : Asymmetric lt) (Hlts : forall x, lt x (idx_succ x)) (Hltt : Transitive lt)
+    (i_snap i_start : idx_map (domain symbol m)) (inst : instance)
+    (q : rule_set idx symbol symbol_map idx_map) (r : erule idx symbol)
+    (frontier_pos : nat) (e_start : instance) :
+    let db_tries := fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
+                           idx_map idx_map_plus idx_trie analysis_result q inst) in
+    let tries := ne_map_idx (fun pos ptr =>
+                               trie_of_clause_sn idx Eqb_idx symbol symbol_map idx_map idx_trie
+                                 (query_vars idx symbol r) db_tries frontier_pos pos ptr)
+                            (query_clause_ptrs idx symbol r) in
+    egraph_sound_for_interpretation i_snap inst ->
+    egraph_ok e_start ->
+    egraph_sound_for_interpretation i_start e_start ->
+    map.extends i_start i_snap ->
+    List.NoDup (query_vars idx symbol r) ->
+    List.NoDup (write_vars idx symbol r) ->
+    erule_sound idx idx_zero symbol symbol_map idx_map m (query_clauses idx symbol symbol_map idx_map q) r ->
+    (forall fsym nptr cvars,
+       In (Build_erule_query_ptr idx symbol fsym nptr cvars)
+          (uncurry cons (query_clause_ptrs idx symbol r)) ->
+       exists q_f cargs cv (Pf : idx -> bool),
+         map.get (query_clauses idx symbol symbol_map idx_map q) fsym = Some q_f
+         /\ map.get q_f nptr = Some (cargs, cv)
+         /\ cvars = filter Pf (query_vars idx symbol r)
+         /\ (forall t, In t cargs -> t < List.length cvars)
+         /\ cv < List.length cvars) ->
+    (forall x, In x (query_vars idx symbol r) ->
+       exists a, In a (query_atoms idx idx_zero symbol symbol_map idx_map (query_clauses idx symbol symbol_map idx_map q) r)
+                 /\ In x (atom_ret a :: atom_args a)) ->
+    (forall x, In x (write_vars idx symbol r) -> ~ In x (query_vars idx symbol r)) ->
+    (forall c, In c (write_clauses idx symbol r) ->
+        forall x, In x (c.(atom_ret) :: c.(atom_args)) ->
+        In x (query_vars idx symbol r) \/ In x (write_vars idx symbol r)) ->
+    (forall p, In p (write_unifications idx symbol r) ->
+        (In (fst p) (query_vars idx symbol r) \/ In (fst p) (write_vars idx symbol r))
+        /\ (In (snd p) (query_vars idx symbol r) \/ In (snd p) (write_vars idx symbol r))) ->
+    (forall sigma, In sigma (intersection_keys idx idx_trie spaced_list_intersect tries) ->
+       List.length (query_vars idx symbol r) = List.length sigma) ->
+    (forall sigma, In sigma (intersection_keys idx idx_trie spaced_list_intersect tries) ->
+       forall pos fsym nptr cvars,
+       nth_error (uncurry cons (query_clause_ptrs idx symbol r)) pos
+         = Some (Build_erule_query_ptr idx symbol fsym nptr cvars) ->
+       map.get (fst (trie_of_clause_sn idx Eqb_idx symbol symbol_map idx_map idx_trie
+                       (query_vars idx symbol r) db_tries frontier_pos pos
+                       (Build_erule_query_ptr idx symbol fsym nptr cvars)))
+               (map fst (filter snd (combine sigma
+                  (variable_flags idx Eqb_idx (query_vars idx symbol r) cvars))))
+       = Some tt) ->
+    match @process_erule'_sn idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie
+            analysis_result _ spaced_list_intersect db_tries r frontier_pos e_start with
+    | (_, e') =>
+        egraph_ok e'
+        /\ exists i', map.extends i' i_snap /\ egraph_sound_for_interpretation i' e'
+    end.
+  Proof.
+    intros db_tries tries Hsnd_inst Hok_start Hsnd_start Hext_start Hnd_qv Hnd_wv Hrule
+           Hwf Hcov Hdisj HcovC HcovU Hlen_sig Hsli.
+    unfold process_erule'_sn.
+    fold tries.
+    set (asn := intersection_keys idx idx_trie spaced_list_intersect tries) in *.
+    assert (Hloop : forall sigmas,
+      (forall sigma, In sigma sigmas -> length (query_vars idx symbol r) = length sigma) ->
+      (forall sigma, In sigma sigmas ->
+         forall pos fsym nptr cvars,
+         nth_error (uncurry cons (query_clause_ptrs idx symbol r)) pos
+           = Some (Build_erule_query_ptr idx symbol fsym nptr cvars) ->
+         map.get (fst (trie_of_clause_sn idx Eqb_idx symbol symbol_map idx_map idx_trie (query_vars idx symbol r) db_tries frontier_pos pos (Build_erule_query_ptr idx symbol fsym nptr cvars)))
+                 (map fst (filter snd (combine sigma (variable_flags idx Eqb_idx (query_vars idx symbol r) cvars)))) = Some tt) ->
+      forall e_cur icur, egraph_ok e_cur -> egraph_sound_for_interpretation icur e_cur -> map.extends icur i_snap ->
+      match list_Miter (exec_write idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result r) sigmas e_cur with
+      | (_, e') => egraph_ok e' /\ exists i', map.extends i' i_snap /\ egraph_sound_for_interpretation i' e'
+      end).
+    { intro sigmas. induction sigmas as [|sigma sigmas' IH];
+        intros Hlen_s Hsli_s e_cur icur Hok_cur Hsnd_cur Hext_cur.
+      - cbn [list_Miter]. split; [exact Hok_cur|].
+        exists icur. split; [exact Hext_cur | exact Hsnd_cur].
+      - cbn [list_Miter].
+        set (env0 := map.of_list (combine (query_vars idx symbol r) sigma)).
+        set (a_q := compose_assignment i_snap env0).
+        assert (Ha_q : forall x, map.get a_q x = match map.get env0 x with Some v => map.get i_snap v | None => None end)
+          by (intros; apply get_compose_assignment).
+        pose proof (query_atoms_sound_sn i_snap q inst r frontier_pos sigma a_q Hsnd_inst Hnd_qv
+                      (Hlen_s sigma (or_introl eq_refl)) Ha_q Hwf (Hsli_s sigma (or_introl eq_refl))) as Hqsnd.
+        pose proof (a_q_wf_query_vars i_snap inst q r a_q env0 Hsnd_inst Ha_q Hqsnd Hcov) as Hawf.
+        destruct (Hrule a_q Hawf Hqsnd) as (a_src & Hsrc_qv & Hsrc_wv & Hsrc_c & Hsrc_u).
+        pose proof (Hlen_s sigma (or_introl eq_refl)) as Hlen1.
+        assert (Hfresh : forall x, In x (write_vars idx symbol r) -> map.get env0 x = None)
+          by (intros x Hxw; unfold env0; apply get_of_list_none;
+              rewrite (map_combine_fst (query_vars idx symbol r) sigma Hlen1); exact (Hdisj x Hxw)).
+        assert (Hcons : forall x v, map.get env0 x = Some v ->
+           map.get icur v = map.get a_src x /\ Sep.has_key v (parent (equiv e_cur)))
+          by (intros x v Hev;
+              assert (Hxq : In x (query_vars idx symbol r))
+                by (pose proof (get_of_list_in_keys idx (combine (query_vars idx symbol r) sigma) x v Hev) as Hk;
+                    rewrite (map_combine_fst (query_vars idx symbol r) sigma Hlen1) in Hk; exact Hk);
+              destruct (Hawf x Hxq) as (d & Haqx & Hwfd);
+              assert (Hiv : map.get i_snap v = Some d) by (rewrite Ha_q, Hev in Haqx; exact Haqx);
+              assert (Hicurv : map.get icur v = Some d) by (apply Hext_cur; exact Hiv);
+              split;
+              [ rewrite Hicurv; rewrite (Hsrc_qv x Hxq); exact (eq_sym Haqx)
+              | apply (interpretation_exact m icur e_cur Hsnd_cur v); rewrite Hicurv; exact I ]).
+        assert (Hcons_c : forall c, In c (write_clauses idx symbol r) ->
+           forall x, In x (atom_ret c :: atom_args c) ->
+           (exists v, map.get env0 x = Some v) \/ In x (write_vars idx symbol r))
+          by (intros c Hc x Hx; destruct (HcovC c Hc x Hx) as [Hq|Hw];
+              [ left; exists (named_list_lookup idx_zero (combine (query_vars idx symbol r) sigma) x);
+                unfold env0; exact (get_of_list_combine idx idx_zero (query_vars idx symbol r) sigma x Hnd_qv Hlen1 Hq)
+              | right; exact Hw ]).
+        assert (Hcons_u : forall p, In p (write_unifications idx symbol r) ->
+           ((exists v, map.get env0 (fst p) = Some v) \/ In (fst p) (write_vars idx symbol r))
+           /\ ((exists v, map.get env0 (snd p) = Some v) \/ In (snd p) (write_vars idx symbol r)))
+          by (intros p Hp; destruct (HcovU p Hp) as [Hf Hs]; split;
+              [ destruct Hf as [Hq|Hw];
+                [ left; exists (named_list_lookup idx_zero (combine (query_vars idx symbol r) sigma) (fst p));
+                  unfold env0; exact (get_of_list_combine idx idx_zero (query_vars idx symbol r) sigma (fst p) Hnd_qv Hlen1 Hq)
+                | right; exact Hw ]
+              | destruct Hs as [Hq|Hw];
+                [ left; exists (named_list_lookup idx_zero (combine (query_vars idx symbol r) sigma) (snd p));
+                  unfold env0; exact (get_of_list_combine idx idx_zero (query_vars idx symbol r) sigma (snd p) Hnd_qv Hlen1 Hq)
+                | right; exact Hw ] ]).
+        pose proof (@exec_write_sound idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol Eqb_symbol Eqb_symbol_ok symbol_map symbol_map_ok idx_map idx_map_ok idx_trie idx_trie_ok analysis_result H m Hm Hlti Hlts Hltt Hm icur r sigma e_cur a_src
+                      Hnd_wv Hfresh Hsrc_wv Hcons Hcons_c Hcons_u Hsrc_c Hsrc_u Hok_cur Hsnd_cur) as Hew.
+        cbn [Mseq Mbind Mret StateMonad.state_monad].
+        destruct (exec_write idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result r sigma e_cur)
+          as [u e_mid] eqn:Hew_eq.
+        destruct Hew as (Hok_mid & _Hmono & i_mid & Hext_mid & Hsnd_mid).
+        assert (Hext_mid_i : map.extends i_mid i_snap)
+          by (intros k vv hh; apply Hext_mid; apply Hext_cur; exact hh).
+        pose proof (IH (fun s Hs => Hlen_s s (or_intror Hs)) (fun s Hs => Hsli_s s (or_intror Hs))
+                      e_mid i_mid Hok_mid Hsnd_mid Hext_mid_i) as HIH.
+        destruct (list_Miter (exec_write idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result r) sigmas' e_mid)
+          as [u2 e'] eqn:Hlm.
+        destruct HIH as (Hok' & i' & Hext'_snap & Hsnd').
+        split; [exact Hok'|].
+        exists i'. split; [exact Hext'_snap | exact Hsnd']. }
+    apply (Hloop asn Hlen_sig Hsli e_start i_start Hok_start Hsnd_start Hext_start).
+  Qed.
+
 End Slice.
 
 (* Soundness of running a single erule across all its frontier positions:
@@ -577,22 +862,24 @@ Lemma process_erule_sound
   (forall p, In p (write_unifications idx symbol r) ->
       (In (fst p) (query_vars idx symbol r) \/ In (fst p) (write_vars idx symbol r))
       /\ (In (snd p) (query_vars idx symbol r) \/ In (snd p) (write_vars idx symbol r))) ->
-  (forall frontier_n sigma,
+  (forall frontier_pos sigma,
      In sigma (intersection_keys idx idx_trie spaced_list_intersect
-                 (ne_map (trie_of_clause idx Eqb_idx symbol symbol_map idx_map idx_trie
-                            (query_vars idx symbol r) db_tries frontier_n)
-                         (query_clause_ptrs idx symbol r))) ->
+                 (ne_map_idx (fun pos ptr =>
+                                trie_of_clause_sn idx Eqb_idx symbol symbol_map idx_map idx_trie
+                                  (query_vars idx symbol r) db_tries frontier_pos pos ptr)
+                             (query_clause_ptrs idx symbol r))) ->
      List.length (query_vars idx symbol r) = List.length sigma) ->
-  (forall frontier_n sigma,
+  (forall frontier_pos sigma,
      In sigma (intersection_keys idx idx_trie spaced_list_intersect
-                 (ne_map (trie_of_clause idx Eqb_idx symbol symbol_map idx_map idx_trie
-                            (query_vars idx symbol r) db_tries frontier_n)
-                         (query_clause_ptrs idx symbol r))) ->
-     forall fsym nptr cvars,
-     In (Build_erule_query_ptr idx symbol fsym nptr cvars)
-        (uncurry cons (query_clause_ptrs idx symbol r)) ->
-     map.get (fst (trie_of_clause idx Eqb_idx symbol symbol_map idx_map idx_trie
-                     (query_vars idx symbol r) db_tries frontier_n
+                 (ne_map_idx (fun pos ptr =>
+                                trie_of_clause_sn idx Eqb_idx symbol symbol_map idx_map idx_trie
+                                  (query_vars idx symbol r) db_tries frontier_pos pos ptr)
+                             (query_clause_ptrs idx symbol r))) ->
+     forall pos fsym nptr cvars,
+     nth_error (uncurry cons (query_clause_ptrs idx symbol r)) pos
+       = Some (Build_erule_query_ptr idx symbol fsym nptr cvars) ->
+     map.get (fst (trie_of_clause_sn idx Eqb_idx symbol symbol_map idx_map idx_trie
+                     (query_vars idx symbol r) db_tries frontier_pos pos
                      (Build_erule_query_ptr idx symbol fsym nptr cvars)))
              (map fst (filter snd (combine sigma
                 (variable_flags idx Eqb_idx (query_vars idx symbol r) cvars))))
@@ -607,41 +894,43 @@ Lemma process_erule_sound
 Proof.
   intros db_tries Hsnd_inst Hok_start Hsnd_start Hext_start Hnd_qv Hnd_wv Hrule
          Hwf Hcov Hdisj HcovC HcovU Hlen_sig Hsli.
-  (* The new [process_erule] aggregates every frontier's intersection keys into a
-     single deduping [idx_trie] and [exec_write]s each unique key once.  Each such
-     key traces back to some frontier (whose per-clause projections all hit), so
-     the deduped loop is sound by [exec_write_loop_sound] with a per-key,
-     existential-in-frontier justification. *)
+  (* The proper semi-naive [process_erule] iterates [process_erule'_sn] over the
+     frontier positions [seq 0 nclauses], threading the egraph.  Each position is
+     sound by [process_erule'_sn_sound] (fixed snapshot [i_snap], evolving loop
+     interpretation); the per-position length/intersection specs are
+     [Hlen_sig]/[Hsli] instantiated at that frontier position. *)
   unfold process_erule. cbv zeta.
-  match goal with
-  | |- context [map.keys ?s] => set (seen := s)
-  end.
-  assert (Hprem : forall sigma, In sigma (map.keys seen) ->
-            exists frontier_n,
-              length (query_vars idx symbol r) = length sigma
-              /\ (forall fsym nptr cvars,
-                    In (Build_erule_query_ptr idx symbol fsym nptr cvars)
-                       (uncurry cons (query_clause_ptrs idx symbol r)) ->
-                    map.get (fst (trie_of_clause idx Eqb_idx symbol symbol_map idx_map idx_trie
-                                    (query_vars idx symbol r) db_tries frontier_n
-                                    (Build_erule_query_ptr idx symbol fsym nptr cvars)))
-                            (map fst (filter snd (combine sigma
-                               (variable_flags idx Eqb_idx (query_vars idx symbol r) cvars))))
-                    = Some tt)).
-  { intros sigma Hin.
-    unfold seen in Hin.
-    apply fold_put_keys_src in Hin.
-    destruct Hin as [Hempty | (n & _Hn_in & Hsig)].
-    - apply map_keys_in in Hempty. destruct Hempty as [v Hv].
-      rewrite map.get_empty in Hv. discriminate.
-    - unfold erule_frontier_keys in Hsig.
-      exists (idx_of_nat idx idx_succ idx_zero n).
-      split.
-      + exact (Hlen_sig (idx_of_nat idx idx_succ idx_zero n) sigma Hsig).
-      + exact (Hsli (idx_of_nat idx idx_succ idx_zero n) sigma Hsig). }
-  apply (exec_write_loop_sound (lt:=lt) (m:=m)
-           Hlti Hlts Hltt i_snap inst q r
-           Hsnd_inst Hnd_qv Hnd_wv Hrule Hwf Hcov Hdisj HcovC HcovU
-           (map.keys seen) Hprem
-           e_start i_start Hok_start Hsnd_start Hext_start).
+  assert (Hloop : forall ps e_cur icur,
+    egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result e_cur ->
+    egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m icur e_cur ->
+    map.extends icur i_snap ->
+    match list_Miter (@process_erule'_sn idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie
+                        analysis_result _ spaced_list_intersect db_tries r) ps e_cur with
+    | (_, e') =>
+        egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result e'
+        /\ exists i', map.extends i' i_snap
+                      /\ egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i' e'
+    end).
+  { intro ps. induction ps as [|p ps' IH]; intros e_cur icur Hok_cur Hsnd_cur Hext_cur.
+    - cbn [list_Miter]. split; [exact Hok_cur|].
+      exists icur. split; [exact Hext_cur | exact Hsnd_cur].
+    - cbn [list_Miter].
+      pose proof (process_erule'_sn_sound Hlti Hlts Hltt i_snap icur inst q r p e_cur
+                    Hsnd_inst Hok_cur Hsnd_cur Hext_cur Hnd_qv Hnd_wv Hrule
+                    Hwf Hcov Hdisj HcovC HcovU (Hlen_sig p) (Hsli p)) as Hstep.
+      cbv zeta in Hstep.
+      fold db_tries in Hstep.
+      cbn [Mseq Mbind Mret StateMonad.state_monad].
+      destruct (@process_erule'_sn idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie
+                  analysis_result _ spaced_list_intersect db_tries r p e_cur)
+        as [u e_mid] eqn:Hpe.
+      destruct Hstep as (Hok_mid & i_mid & Hext_mid & Hsnd_mid).
+      pose proof (IH e_mid i_mid Hok_mid Hsnd_mid Hext_mid) as HIH.
+      destruct (list_Miter (@process_erule'_sn idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie
+                              analysis_result _ spaced_list_intersect db_tries r) ps' e_mid)
+        as [u2 e'] eqn:Hlm.
+      destruct HIH as (Hok' & i' & Hext'_snap & Hsnd').
+      split; [exact Hok'|].
+      exists i'. split; [exact Hext'_snap | exact Hsnd']. }
+  apply (Hloop _ e_start i_start Hok_start Hsnd_start Hext_start).
 Qed.

--- a/src/Utils/EGraph/SemanticsProcessErule.v
+++ b/src/Utils/EGraph/SemanticsProcessErule.v
@@ -5,7 +5,7 @@
 From Stdlib Require Import Lists.List Classes.RelationClasses BinNums.
 Import ListNotations.
 From coqutil Require Import Map.Interface.
-From Utils Require Import Utils UnionFind Monad ExtraMaps VC Relations.
+From Utils Require Import Utils UnionFind Monad ExtraMaps VC Relations Maps.
 From Utils.EGraph Require Import Defs Semantics SemanticsUtil SemanticsExecConst.
 Import Monad.StateMonad.
 
@@ -218,6 +218,166 @@ Section Slice.
     rewrite Ha_q in Hd.
     destruct (map.get env0 x) as [v|] eqn:Henv; [|discriminate].
     exact (idx_interpretation_wf m i inst Hsnd v d Hd).
+  Qed.
+
+  (* --- deduped-keys book-keeping for the new [process_erule] --- *)
+
+  (* A key surviving the inner per-frontier [map.put] fold came either from the
+     frontier's key list [ks] or was already present in [acc]. *)
+  Lemma fold_put_keys_inner (ks : list (list idx)) (acc : idx_trie unit) (sigma : list idx) :
+    In sigma (map.keys (List.fold_left (fun acc' k => map.put acc' k tt) ks acc))
+    -> In sigma ks \/ In sigma (map.keys acc).
+  Proof.
+    revert acc; induction ks as [|k ks' IH]; intros acc Hin; cbn [List.fold_left] in Hin.
+    - right. exact Hin.
+    - destruct (IH (map.put acc k tt) Hin) as [Hks' | Hput].
+      + left. right. exact Hks'.
+      + rewrite map_keys_in' in Hput.
+        pose proof (@eqb_spec (list idx) _ _ sigma k) as Hbs.
+        destruct (eqb sigma k) eqn:Hsk.
+        * left. left. exact (eq_sym Hbs).
+        * rewrite (map.get_put_diff acc sigma tt k Hbs) in Hput.
+          right. rewrite map_keys_in'. exact Hput.
+  Qed.
+
+  (* A key in the fully-deduped [seen] trie traces back to some frontier index
+     [n] in [ns] whose key list [f n] contains it (or it was already in [acc0]). *)
+  Lemma fold_put_keys_src {N : Type} (f : N -> list (list idx)) (ns : list N)
+    (acc0 : idx_trie unit) (sigma : list idx) :
+    In sigma (map.keys (List.fold_left
+                (fun acc n => List.fold_left (fun acc' k => map.put acc' k tt) (f n) acc)
+                ns acc0))
+    -> In sigma (map.keys acc0) \/ exists n, In n ns /\ In sigma (f n).
+  Proof.
+    revert acc0; induction ns as [|n ns' IH]; intros acc0 Hin; cbn [List.fold_left] in Hin.
+    - left. exact Hin.
+    - destruct (IH _ Hin) as [Hacc1 | (n' & Hn'_in & Hsig)].
+      + destruct (fold_put_keys_inner (f n) acc0 sigma Hacc1) as [Hfn | Hacc0].
+        * right. exists n. split; [left; reflexivity | exact Hfn].
+        * left. exact Hacc0.
+      + right. exists n'. split; [right; exact Hn'_in | exact Hsig].
+  Qed.
+
+  (* Generalised exec-write loop: run [exec_write r] over a list of intersection
+     keys where each key is justified by SOME frontier (its per-clause projections
+     all hit their clause tries under that frontier).  This is the soundness core
+     shared by the per-frontier [process_erule'] and the deduped [process_erule];
+     the latter aggregates keys from different frontiers, so the per-key
+     justification is existential in the frontier. *)
+  Lemma exec_write_loop_sound
+    (Hlti : Asymmetric lt) (Hlts : forall x, lt x (idx_succ x)) (Hltt : Transitive lt)
+    (i_snap : idx_map (domain symbol m)) (inst : instance)
+    (q : rule_set idx symbol symbol_map idx_map) (r : erule idx symbol) :
+    let db_tries := fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
+                           idx_map idx_map_plus idx_trie analysis_result q inst) in
+    egraph_sound_for_interpretation i_snap inst ->
+    List.NoDup (query_vars idx symbol r) ->
+    List.NoDup (write_vars idx symbol r) ->
+    erule_sound idx idx_zero symbol symbol_map idx_map m (query_clauses idx symbol symbol_map idx_map q) r ->
+    (forall fsym nptr cvars,
+       In (Build_erule_query_ptr idx symbol fsym nptr cvars)
+          (uncurry cons (query_clause_ptrs idx symbol r)) ->
+       exists q_f cargs cv (Pf : idx -> bool),
+         map.get (query_clauses idx symbol symbol_map idx_map q) fsym = Some q_f
+         /\ map.get q_f nptr = Some (cargs, cv)
+         /\ cvars = filter Pf (query_vars idx symbol r)
+         /\ (forall t, In t cargs -> t < List.length cvars)
+         /\ cv < List.length cvars) ->
+    (forall x, In x (query_vars idx symbol r) ->
+       exists a, In a (query_atoms idx idx_zero symbol symbol_map idx_map (query_clauses idx symbol symbol_map idx_map q) r)
+                 /\ In x (atom_ret a :: atom_args a)) ->
+    (forall x, In x (write_vars idx symbol r) -> ~ In x (query_vars idx symbol r)) ->
+    (forall c, In c (write_clauses idx symbol r) ->
+        forall x, In x (c.(atom_ret) :: c.(atom_args)) ->
+        In x (query_vars idx symbol r) \/ In x (write_vars idx symbol r)) ->
+    (forall p, In p (write_unifications idx symbol r) ->
+        (In (fst p) (query_vars idx symbol r) \/ In (fst p) (write_vars idx symbol r))
+        /\ (In (snd p) (query_vars idx symbol r) \/ In (snd p) (write_vars idx symbol r))) ->
+    forall sigmas,
+    (forall sigma, In sigma sigmas ->
+       exists frontier_n,
+         List.length (query_vars idx symbol r) = List.length sigma
+         /\ (forall fsym nptr cvars,
+              In (Build_erule_query_ptr idx symbol fsym nptr cvars)
+                 (uncurry cons (query_clause_ptrs idx symbol r)) ->
+              map.get (fst (trie_of_clause idx Eqb_idx symbol symbol_map idx_map idx_trie
+                              (query_vars idx symbol r) db_tries frontier_n
+                              (Build_erule_query_ptr idx symbol fsym nptr cvars)))
+                      (map fst (filter snd (combine sigma
+                         (variable_flags idx Eqb_idx (query_vars idx symbol r) cvars))))
+              = Some tt)) ->
+    forall e_cur icur,
+      egraph_ok e_cur -> egraph_sound_for_interpretation icur e_cur -> map.extends icur i_snap ->
+    match list_Miter (exec_write idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result r) sigmas e_cur with
+    | (_, e') =>
+        egraph_ok e'
+        /\ exists i', map.extends i' i_snap /\ egraph_sound_for_interpretation i' e'
+    end.
+  Proof.
+    intros db_tries Hsnd_inst Hnd_qv Hnd_wv Hrule Hwf Hcov Hdisj HcovC HcovU.
+    intro sigmas. induction sigmas as [|sigma sigmas' IH];
+      intros Hprem e_cur icur Hok_cur Hsnd_cur Hext_cur.
+    - cbn [list_Miter]. split; [exact Hok_cur|].
+      exists icur. split; [exact Hext_cur | exact Hsnd_cur].
+    - cbn [list_Miter].
+      destruct (Hprem sigma (or_introl eq_refl)) as (frontier_n & Hlen1 & Hsli_sigma).
+      set (env0 := map.of_list (combine (query_vars idx symbol r) sigma)).
+      set (a_q := compose_assignment i_snap env0).
+      assert (Ha_q : forall x, map.get a_q x = match map.get env0 x with Some v => map.get i_snap v | None => None end)
+        by (intros; apply get_compose_assignment).
+      pose proof (query_atoms_sound i_snap q inst r frontier_n sigma a_q Hsnd_inst Hnd_qv
+                    Hlen1 Ha_q Hwf Hsli_sigma) as Hqsnd.
+      pose proof (a_q_wf_query_vars i_snap inst q r a_q env0 Hsnd_inst Ha_q Hqsnd Hcov) as Hawf.
+      destruct (Hrule a_q Hawf Hqsnd) as (a_src & Hsrc_qv & Hsrc_wv & Hsrc_c & Hsrc_u).
+      assert (Hfresh : forall x, In x (write_vars idx symbol r) -> map.get env0 x = None)
+        by (intros x Hxw; unfold env0; apply get_of_list_none;
+            rewrite (map_combine_fst (query_vars idx symbol r) sigma Hlen1); exact (Hdisj x Hxw)).
+      assert (Hcons : forall x v, map.get env0 x = Some v ->
+         map.get icur v = map.get a_src x /\ Sep.has_key v (parent (equiv e_cur)))
+        by (intros x v Hev;
+            assert (Hxq : In x (query_vars idx symbol r))
+              by (pose proof (get_of_list_in_keys idx (combine (query_vars idx symbol r) sigma) x v Hev) as Hk;
+                  rewrite (map_combine_fst (query_vars idx symbol r) sigma Hlen1) in Hk; exact Hk);
+            destruct (Hawf x Hxq) as (d & Haqx & Hwfd);
+            assert (Hiv : map.get i_snap v = Some d) by (rewrite Ha_q, Hev in Haqx; exact Haqx);
+            assert (Hicurv : map.get icur v = Some d) by (apply Hext_cur; exact Hiv);
+            split;
+            [ rewrite Hicurv; rewrite (Hsrc_qv x Hxq); exact (eq_sym Haqx)
+            | apply (interpretation_exact m icur e_cur Hsnd_cur v); rewrite Hicurv; exact I ]).
+      assert (Hcons_c : forall c, In c (write_clauses idx symbol r) ->
+         forall x, In x (atom_ret c :: atom_args c) ->
+         (exists v, map.get env0 x = Some v) \/ In x (write_vars idx symbol r))
+        by (intros c Hc x Hx; destruct (HcovC c Hc x Hx) as [Hq|Hw];
+            [ left; exists (named_list_lookup idx_zero (combine (query_vars idx symbol r) sigma) x);
+              unfold env0; exact (get_of_list_combine idx idx_zero (query_vars idx symbol r) sigma x Hnd_qv Hlen1 Hq)
+            | right; exact Hw ]).
+      assert (Hcons_u : forall p, In p (write_unifications idx symbol r) ->
+         ((exists v, map.get env0 (fst p) = Some v) \/ In (fst p) (write_vars idx symbol r))
+         /\ ((exists v, map.get env0 (snd p) = Some v) \/ In (snd p) (write_vars idx symbol r)))
+        by (intros p Hp; destruct (HcovU p Hp) as [Hf Hs]; split;
+            [ destruct Hf as [Hq|Hw];
+              [ left; exists (named_list_lookup idx_zero (combine (query_vars idx symbol r) sigma) (fst p));
+                unfold env0; exact (get_of_list_combine idx idx_zero (query_vars idx symbol r) sigma (fst p) Hnd_qv Hlen1 Hq)
+              | right; exact Hw ]
+            | destruct Hs as [Hq|Hw];
+              [ left; exists (named_list_lookup idx_zero (combine (query_vars idx symbol r) sigma) (snd p));
+                unfold env0; exact (get_of_list_combine idx idx_zero (query_vars idx symbol r) sigma (snd p) Hnd_qv Hlen1 Hq)
+              | right; exact Hw ] ]).
+      pose proof (@exec_write_sound idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol Eqb_symbol Eqb_symbol_ok symbol_map symbol_map_ok idx_map idx_map_ok idx_trie idx_trie_ok analysis_result H m Hm Hlti Hlts Hltt Hm icur r sigma e_cur a_src
+                    Hnd_wv Hfresh Hsrc_wv Hcons Hcons_c Hcons_u Hsrc_c Hsrc_u Hok_cur Hsnd_cur) as Hew.
+      cbn [Mseq Mbind Mret StateMonad.state_monad].
+      destruct (exec_write idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result r sigma e_cur)
+        as [u e_mid] eqn:Hew_eq.
+      destruct Hew as (Hok_mid & _Hmono & i_mid & Hext_mid & Hsnd_mid).
+      assert (Hext_mid_i : map.extends i_mid i_snap)
+        by (intros k vv hh; apply Hext_mid; apply Hext_cur; exact hh).
+      pose proof (IH (fun s Hs => Hprem s (or_intror Hs))
+                    e_mid i_mid Hok_mid Hsnd_mid Hext_mid_i) as HIH.
+      destruct (list_Miter (exec_write idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result r) sigmas' e_mid)
+        as [u2 e'] eqn:Hlm.
+      destruct HIH as (Hok' & i' & Hext'_snap & Hsnd').
+      split; [exact Hok'|].
+      exists i'. split; [exact Hext'_snap | exact Hsnd'].
   Qed.
 
   (* Soundness of one frontier iteration of a single erule: running
@@ -447,29 +607,41 @@ Lemma process_erule_sound
 Proof.
   intros db_tries Hsnd_inst Hok_start Hsnd_start Hext_start Hnd_qv Hnd_wv Hrule
          Hwf Hcov Hdisj HcovC HcovU Hlen_sig Hsli.
-  unfold process_erule.
-  assert (Hloop : forall ns,
-    forall e_cur icur, egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result e_cur -> egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m icur e_cur -> map.extends icur i_snap ->
-    match list_Miter (fun n => process_erule' idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result spaced_list_intersect db_tries r (idx_of_nat idx idx_succ idx_zero n)) ns e_cur with
-    | (_, e') => egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result e' /\ exists i', map.extends i' i_snap /\ egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i' e'
-    end).
-  { induction ns as [|n ns' IH]; intros e_cur icur Hok_cur Hsnd_cur Hext_cur.
-    - cbn [list_Miter]. split; [exact Hok_cur|].
-      exists icur. split; [exact Hext_cur | exact Hsnd_cur].
-    - cbn [list_Miter].
-      pose proof (process_erule'_sound (lt:=lt) (m:=m) (spaced_list_intersect:=spaced_list_intersect) Hlti Hlts Hltt i_snap icur inst q r (idx_of_nat idx idx_succ idx_zero n) e_cur
-                    Hsnd_inst Hok_cur Hsnd_cur Hext_cur Hnd_qv Hnd_wv Hrule Hwf Hcov Hdisj HcovC HcovU
-                    (Hlen_sig (idx_of_nat idx idx_succ idx_zero n)) (Hsli (idx_of_nat idx idx_succ idx_zero n))) as Hpe.
-      cbn [Mseq Mbind Mret StateMonad.state_monad].
-      fold db_tries in Hpe.
-      destruct (process_erule' idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result spaced_list_intersect db_tries r (idx_of_nat idx idx_succ idx_zero n) e_cur)
-        as [u e_mid] eqn:Hpe_eq.
-      destruct Hpe as (Hok_mid & i_mid & Hext_mid & Hsnd_mid).
-      pose proof (IH e_mid i_mid Hok_mid Hsnd_mid Hext_mid) as HIH.
-      destruct (list_Miter (fun n0 => process_erule' idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result spaced_list_intersect db_tries r (idx_of_nat idx idx_succ idx_zero n0)) ns' e_mid)
-        as [u2 e'] eqn:Hlm.
-      destruct HIH as (Hok' & i' & Hext'_snap & Hsnd').
-      split; [exact Hok'|]. exists i'. split; [exact Hext'_snap | exact Hsnd']. }
-  apply (Hloop (seq 0 (length (uncurry cons (query_clause_ptrs idx symbol r))))
-               e_start i_start Hok_start Hsnd_start Hext_start).
+  (* The new [process_erule] aggregates every frontier's intersection keys into a
+     single deduping [idx_trie] and [exec_write]s each unique key once.  Each such
+     key traces back to some frontier (whose per-clause projections all hit), so
+     the deduped loop is sound by [exec_write_loop_sound] with a per-key,
+     existential-in-frontier justification. *)
+  unfold process_erule. cbv zeta.
+  match goal with
+  | |- context [map.keys ?s] => set (seen := s)
+  end.
+  assert (Hprem : forall sigma, In sigma (map.keys seen) ->
+            exists frontier_n,
+              length (query_vars idx symbol r) = length sigma
+              /\ (forall fsym nptr cvars,
+                    In (Build_erule_query_ptr idx symbol fsym nptr cvars)
+                       (uncurry cons (query_clause_ptrs idx symbol r)) ->
+                    map.get (fst (trie_of_clause idx Eqb_idx symbol symbol_map idx_map idx_trie
+                                    (query_vars idx symbol r) db_tries frontier_n
+                                    (Build_erule_query_ptr idx symbol fsym nptr cvars)))
+                            (map fst (filter snd (combine sigma
+                               (variable_flags idx Eqb_idx (query_vars idx symbol r) cvars))))
+                    = Some tt)).
+  { intros sigma Hin.
+    unfold seen in Hin.
+    apply fold_put_keys_src in Hin.
+    destruct Hin as [Hempty | (n & _Hn_in & Hsig)].
+    - apply map_keys_in in Hempty. destruct Hempty as [v Hv].
+      rewrite map.get_empty in Hv. discriminate.
+    - unfold erule_frontier_keys in Hsig.
+      exists (idx_of_nat idx idx_succ idx_zero n).
+      split.
+      + exact (Hlen_sig (idx_of_nat idx idx_succ idx_zero n) sigma Hsig).
+      + exact (Hsli (idx_of_nat idx idx_succ idx_zero n) sigma Hsig). }
+  apply (exec_write_loop_sound (lt:=lt) (m:=m)
+           Hlti Hlts Hltt i_snap inst q r
+           Hsnd_inst Hnd_qv Hnd_wv Hrule Hwf Hcov Hdisj HcovC HcovU
+           (map.keys seen) Hprem
+           e_start i_start Hok_start Hsnd_start Hext_start).
 Qed.

--- a/src/Utils/EGraph/SemanticsSaturate.v
+++ b/src/Utils/EGraph/SemanticsSaturate.v
@@ -98,22 +98,24 @@ Section Slice.
     /\ (forall p, In p (write_unifications idx symbol r) ->
           (In (fst p) (query_vars idx symbol r) \/ In (fst p) (write_vars idx symbol r))
           /\ (In (snd p) (query_vars idx symbol r) \/ In (snd p) (write_vars idx symbol r)))
-    /\ (forall frontier_n sigma,
+    /\ (forall frontier_pos sigma,
          In sigma (intersection_keys idx idx_trie spaced_list_intersect
-                     (ne_map (trie_of_clause idx Eqb_idx symbol symbol_map idx_map idx_trie
-                                (query_vars idx symbol r) db_tries frontier_n)
-                             (query_clause_ptrs idx symbol r))) ->
+                     (ne_map_idx (fun pos ptr =>
+                                    trie_of_clause_sn idx Eqb_idx symbol symbol_map idx_map idx_trie
+                                      (query_vars idx symbol r) db_tries frontier_pos pos ptr)
+                                 (query_clause_ptrs idx symbol r))) ->
          List.length (query_vars idx symbol r) = List.length sigma)
-    /\ (forall frontier_n sigma,
+    /\ (forall frontier_pos sigma,
          In sigma (intersection_keys idx idx_trie spaced_list_intersect
-                     (ne_map (trie_of_clause idx Eqb_idx symbol symbol_map idx_map idx_trie
-                                (query_vars idx symbol r) db_tries frontier_n)
-                             (query_clause_ptrs idx symbol r))) ->
-         forall fsym nptr cvars,
-         In (Build_erule_query_ptr idx symbol fsym nptr cvars)
-            (uncurry cons (query_clause_ptrs idx symbol r)) ->
-         map.get (fst (trie_of_clause idx Eqb_idx symbol symbol_map idx_map idx_trie
-                         (query_vars idx symbol r) db_tries frontier_n
+                     (ne_map_idx (fun pos ptr =>
+                                    trie_of_clause_sn idx Eqb_idx symbol symbol_map idx_map idx_trie
+                                      (query_vars idx symbol r) db_tries frontier_pos pos ptr)
+                                 (query_clause_ptrs idx symbol r))) ->
+         forall pos fsym nptr cvars,
+         nth_error (uncurry cons (query_clause_ptrs idx symbol r)) pos
+           = Some (Build_erule_query_ptr idx symbol fsym nptr cvars) ->
+         map.get (fst (trie_of_clause_sn idx Eqb_idx symbol symbol_map idx_map idx_trie
+                         (query_vars idx symbol r) db_tries frontier_pos pos
                          (Build_erule_query_ptr idx symbol fsym nptr cvars)))
                  (map fst (filter snd (combine sigma
                     (variable_flags idx Eqb_idx (query_vars idx symbol r) cvars))))

--- a/src/Utils/EGraph/SemanticsSaturate.v
+++ b/src/Utils/EGraph/SemanticsSaturate.v
@@ -18,6 +18,7 @@ Section Slice.
     {lt : idx -> idx -> Prop}
     {idx_succ : idx -> idx}
     {idx_zero : WithDefault idx}
+    {idx_leb : idx -> idx -> bool}
     {symbol : Type}
     {Eqb_symbol : Eqb symbol}
     {Eqb_symbol_ok : Eqb_ok Eqb_symbol}
@@ -63,6 +64,7 @@ Section Slice.
   (* run1iter_rule_hyps — external, explicit ctx binders *)
   Definition run1iter_rule_hyps
     (idx : Type) (Eqb_idx : Eqb idx) (idx_zero : WithDefault idx)
+    (idx_succ_rh : idx -> idx) (idx_leb_rh : idx -> idx -> bool) (window_rh : nat)
     (symbol : Type) (symbol_map : forall A, map.map symbol A)
     (symbol_map_plus : map_plus symbol_map)
     (idx_map : forall A, map.map idx A) (idx_map_plus : map_plus idx_map)
@@ -74,8 +76,8 @@ Section Slice.
     (q : rule_set idx symbol symbol_map idx_map)
     (inst : Defs.instance idx symbol symbol_map idx_map idx_trie analysis_result)
     (r : erule idx symbol) : Prop :=
-    let db_tries := fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus
-                           idx_map idx_map_plus idx_trie analysis_result q inst) in
+    let db_tries := fst (build_tries idx Eqb_idx idx_succ_rh idx_leb_rh symbol symbol_map symbol_map_plus
+                           idx_map idx_map_plus idx_trie analysis_result window_rh q inst) in
     List.NoDup (query_vars idx symbol r)
     /\ List.NoDup (write_vars idx symbol r)
     /\ erule_sound idx idx_zero symbol symbol_map idx_map m (query_clauses idx symbol symbol_map idx_map q) r
@@ -124,36 +126,36 @@ Section Slice.
   (* run1iter_sound — internal, implicit ctx *)
   Lemma run1iter_sound
     (Hlti : Asymmetric lt) (Hlts : forall x, lt x (idx_succ x)) (Hltt : Transitive lt)
-    (rebuild_fuel : nat)
+    (rebuild_fuel : nat) (window : nat)
     (i_0 : idx_map (domain symbol m))
     (rs : rule_set idx symbol symbol_map idx_map)
     (e_0 : instance) :
     egraph_ok e_0 ->
     egraph_sound_for_interpretation i_0 e_0 ->
     (forall r, In r (compiled_rules idx symbol symbol_map idx_map rs) ->
-       run1iter_rule_hyps idx Eqb_idx idx_zero symbol symbol_map symbol_map_plus
+       run1iter_rule_hyps idx Eqb_idx idx_zero idx_succ idx_leb window symbol symbol_map symbol_map_plus
          idx_map idx_map_plus idx_trie analysis_result spaced_list_intersect m rs e_0 r) ->
-    match Defs.run1iter idx Eqb_idx idx_succ idx_zero symbol symbol_map symbol_map_plus
-            idx_map idx_map_plus idx_trie analysis_result spaced_list_intersect rebuild_fuel rs e_0 with
+    match Defs.run1iter idx Eqb_idx idx_succ idx_zero idx_leb symbol symbol_map symbol_map_plus
+            idx_map idx_map_plus idx_trie analysis_result spaced_list_intersect rebuild_fuel window rs e_0 with
     | (_, e') => egraph_ok e' /\ exists i', map.extends i' i_0 /\ egraph_sound_for_interpretation i' e'
     end.
   Proof.
     intros Hok_0 Hsnd_0 Hrules.
     unfold Defs.run1iter.
     cbn [Mbind Mseq Mret StateMonad.state_monad].
-    destruct (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus idx_map idx_map_plus idx_trie analysis_result rs e_0) as [tries e0'] eqn:Hbt.
-    unfold build_tries in Hbt. inversion Hbt as [ [Htries He0'] ]. subst e0'.
+    destruct (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus idx_map idx_map_plus idx_trie analysis_result window rs e_0) as [tries e0'] eqn:Hbt.
+    cbn [build_tries] in Hbt. inversion Hbt as [ [Htries He0'] ]. subst e0'.
     cbn [max_id worklist_empty].
     clear Hbt Htries tries.
     destruct (increment_epoch idx idx_succ symbol symbol_map idx_map idx_trie analysis_result e_0) as [u1 e_1] eqn:Hie.
     pose proof (increment_epoch_preserves e_0) as [Hok1f Hs1f].
     rewrite Hie in Hok1f, Hs1f. cbn [snd] in Hok1f, Hs1f.
     specialize (Hok1f Hok_0).
-    set (db_tries := fst (build_tries idx Eqb_idx symbol symbol_map symbol_map_plus idx_map idx_map_plus idx_trie analysis_result rs e_0)).
-    change (map_intersect (build_tries_for_symbol idx Eqb_idx idx_map idx_map_plus idx_trie analysis_result (epoch e_0)) (query_clauses idx symbol symbol_map idx_map rs) (db e_0)) with db_tries.
+    set (db_tries := fst (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus idx_map idx_map_plus idx_trie analysis_result window rs e_0)).
+    change (map_intersect (build_tries_for_symbol idx Eqb_idx idx_succ idx_leb idx_map idx_map_plus idx_trie analysis_result (epoch e_0) window) (query_clauses idx symbol symbol_map idx_map rs) (db e_0)) with db_tries.
     pose proof (Hs1f i_0 Hsnd_0) as Hsnd_1.
     assert (Hloop : forall rules e_cur i_cur,
-      (forall r, In r rules -> run1iter_rule_hyps idx Eqb_idx idx_zero symbol symbol_map symbol_map_plus
+      (forall r, In r rules -> run1iter_rule_hyps idx Eqb_idx idx_zero idx_succ idx_leb window symbol symbol_map symbol_map_plus
                                   idx_map idx_map_plus idx_trie analysis_result spaced_list_intersect m rs e_0 r) ->
       egraph_ok e_cur -> egraph_sound_for_interpretation i_cur e_cur -> map.extends i_cur i_0 ->
       match list_Miter (process_erule idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result spaced_list_intersect db_tries) rules e_cur with
@@ -166,11 +168,11 @@ Section Slice.
         assert (Hin : In r (r :: rules')) by (left; reflexivity).
         pose proof (Hrh r Hin) as Hrhr.
         destruct Hrhr as (Hnd_qv & Hnd_wv & Hrule & Hwf & Hcov & Hdisj & HcovC & HcovU & Hlen & Hsli).
-        pose proof (@process_erule_sound idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol Eqb_symbol Eqb_symbol_ok symbol_map symbol_map_plus symbol_map_plus_ok symbol_map_ok idx_map idx_map_plus idx_map_ok idx_trie idx_trie_ok analysis_result idx_map_plus_ok spaced_list_intersect H m Hm Hlti Hlts Hltt i_0 i_cur e_0 rs r e_cur Hsnd_0 Hok_cur Hsnd_cur Hext_cur Hnd_qv Hnd_wv Hrule Hwf Hcov Hdisj HcovC HcovU Hlen Hsli) as Hpe.
+        pose proof (@process_erule_sound idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero idx_leb symbol Eqb_symbol Eqb_symbol_ok symbol_map symbol_map_plus symbol_map_plus_ok symbol_map_ok idx_map idx_map_plus idx_map_ok idx_trie idx_trie_ok analysis_result idx_map_plus_ok spaced_list_intersect H m Hm Hlti Hlts Hltt window i_0 i_cur e_0 rs r e_cur Hsnd_0 Hok_cur Hsnd_cur Hext_cur Hnd_qv Hnd_wv Hrule Hwf Hcov Hdisj HcovC HcovU Hlen Hsli) as Hpe.
         fold db_tries in Hpe.
         destruct (process_erule idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result spaced_list_intersect db_tries r e_cur) as [u e_mid] eqn:Hpe_eq.
         destruct Hpe as (Hok_mid & i_mid & Hext_mid & Hsnd_mid).
-        assert (Hrh' : forall r0, In r0 rules' -> run1iter_rule_hyps idx Eqb_idx idx_zero symbol symbol_map symbol_map_plus
+        assert (Hrh' : forall r0, In r0 rules' -> run1iter_rule_hyps idx Eqb_idx idx_zero idx_succ idx_leb window symbol symbol_map symbol_map_plus
                                                      idx_map idx_map_plus idx_trie analysis_result spaced_list_intersect m rs e_0 r0) by (intros r0 Hr0; apply Hrh; right; exact Hr0).
         pose proof (IH e_mid i_mid Hrh' Hok_mid Hsnd_mid Hext_mid) as HIH.
         destruct (list_Miter (process_erule idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result spaced_list_intersect db_tries) rules' e_mid) as [u2 e'] eqn:Hlm.
@@ -196,18 +198,21 @@ Section Slice.
     (P : state instance bool)
     (HP : forall e i, egraph_ok e -> egraph_sound_for_interpretation i e ->
             egraph_ok (snd (P e)) /\ egraph_sound_for_interpretation i (snd (P e)))
-    (Hrules : forall e r, In r (compiled_rules idx symbol symbol_map idx_map rs) ->
-       run1iter_rule_hyps idx Eqb_idx idx_zero symbol symbol_map symbol_map_plus
+    (* quantified over ALL windows: the first iteration of a phase uses the
+       schedule-derived catch-up window, but [saturate_until'] recurses with
+       window := 0, so the IH must cover an arbitrary window per step. *)
+    (Hrules : forall w e r, In r (compiled_rules idx symbol symbol_map idx_map rs) ->
+       run1iter_rule_hyps idx Eqb_idx idx_zero idx_succ idx_leb w symbol symbol_map symbol_map_plus
          idx_map idx_map_plus idx_trie analysis_result spaced_list_intersect m rs e r)
     (fuel : nat) :
-    forall (i_0 : idx_map (domain symbol m)) (e_0 : instance),
+    forall (window : nat) (i_0 : idx_map (domain symbol m)) (e_0 : instance),
     egraph_ok e_0 ->
     egraph_sound_for_interpretation i_0 e_0 ->
-    match Defs.saturate_until' idx_succ idx_zero spaced_list_intersect rebuild_fuel rs P fuel e_0 with
+    match Defs.saturate_until' idx_succ idx_zero idx_leb spaced_list_intersect rebuild_fuel window rs P fuel e_0 with
     | (_, e') => egraph_ok e' /\ exists i', map.extends i' i_0 /\ egraph_sound_for_interpretation i' e'
     end.
   Proof.
-    induction fuel as [|fuel IH]; intros i_0 e_0 Hok_0 Hsnd_0.
+    induction fuel as [|fuel IH]; intros window i_0 e_0 Hok_0 Hsnd_0.
     - cbn [Defs.saturate_until' Mret StateMonad.state_monad].
       split; [exact Hok_0|]. exists i_0. split; [apply Properties.map.extends_refl | exact Hsnd_0].
     - cbn [Defs.saturate_until'].
@@ -217,13 +222,13 @@ Section Slice.
       cbn [snd] in HokP, HsndP.
       destruct doneP.
       { split; [exact HokP|]. exists i_0. split; [apply Properties.map.extends_refl | exact HsndP]. }
-      pose proof (run1iter_sound Hlti Hlts Hltt rebuild_fuel i_0 rs eP HokP HsndP (fun r Hr => Hrules eP r Hr)) as Hri.
-      destruct (Defs.run1iter idx Eqb_idx idx_succ idx_zero symbol symbol_map symbol_map_plus idx_map idx_map_plus idx_trie analysis_result spaced_list_intersect rebuild_fuel rs eP) as [nc e2] eqn:Hru.
+      pose proof (run1iter_sound Hlti Hlts Hltt rebuild_fuel window i_0 rs eP HokP HsndP (fun r Hr => Hrules window eP r Hr)) as Hri.
+      destruct (Defs.run1iter idx Eqb_idx idx_succ idx_zero idx_leb symbol symbol_map symbol_map_plus idx_map idx_map_plus idx_trie analysis_result spaced_list_intersect rebuild_fuel window rs eP) as [nc e2] eqn:Hru.
       destruct Hri as (Hok2 & i_1 & Hext1 & Hsnd2).
       destruct nc.
       { split; [exact Hok2|]. exists i_1. split; [exact Hext1 | exact Hsnd2]. }
-      pose proof (IH i_1 e2 Hok2 Hsnd2) as HIH.
-      destruct (saturate_until' idx_succ idx_zero spaced_list_intersect rebuild_fuel rs P fuel e2) as [b e_final] eqn:Hsat.
+      pose proof (IH 0 i_1 e2 Hok2 Hsnd2) as HIH.
+      destruct (saturate_until' idx_succ idx_zero idx_leb spaced_list_intersect rebuild_fuel 0 rs P fuel e2) as [b e_final] eqn:Hsat.
       destruct HIH as (Hok_final & i_f & Hext_f & Hsnd_final).
       split; [exact Hok_final|]. exists i_f.
       split; [eapply map_extends_trans; [exact Hext_f | exact Hext1] | exact Hsnd_final].
@@ -235,6 +240,7 @@ End Slice.
 Lemma saturate_until_sound
   (idx : Type) (Eqb_idx : Eqb idx) (Eqb_idx_ok : Eqb_ok Eqb_idx)
   (lt : idx -> idx -> Prop) (idx_succ : idx -> idx) (idx_zero : WithDefault idx)
+  (idx_leb : idx -> idx -> bool)
   (symbol : Type) (Eqb_symbol : Eqb symbol) (Eqb_symbol_ok : Eqb_ok Eqb_symbol)
   (symbol_map : forall A, map.map symbol A) (symbol_map_plus : map_plus symbol_map)
   (symbol_map_plus_ok : @map_plus_ok _ _ symbol_map_plus)
@@ -252,7 +258,7 @@ Lemma saturate_until_sound
   (m : model symbol)
   (Hm : model_ok symbol m)
   (Hlti : Asymmetric lt) (Hlts : forall x, lt x (idx_succ x)) (Hltt : Transitive lt)
-  (rebuild_fuel : nat)
+  (window : nat) (rebuild_fuel : nat)
   (rs : rule_set idx symbol symbol_map idx_map)
   (P : state (Defs.instance idx symbol symbol_map idx_map idx_trie analysis_result) bool)
   (HP : forall e i, Semantics.egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result e ->
@@ -263,14 +269,14 @@ Lemma saturate_until_sound
           Semantics.egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i e ->
           Semantics.egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result (snd (process_const_rules idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result rs e))
           /\ exists i', map.extends i' i /\ Semantics.egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i' (snd (process_const_rules idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result rs e)))
-  (Hrules : forall e r, In r (compiled_rules idx symbol symbol_map idx_map rs) ->
-     run1iter_rule_hyps idx Eqb_idx idx_zero symbol symbol_map symbol_map_plus
+  (Hrules : forall w e r, In r (compiled_rules idx symbol symbol_map idx_map rs) ->
+     run1iter_rule_hyps idx Eqb_idx idx_zero idx_succ idx_leb w symbol symbol_map symbol_map_plus
        idx_map idx_map_plus idx_trie analysis_result spaced_list_intersect m rs e r)
   (fuel : nat)
   (i_0 : idx_map (domain symbol m)) (e_0 : Defs.instance idx symbol symbol_map idx_map idx_trie analysis_result) :
   Semantics.egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result e_0 ->
   Semantics.egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i_0 e_0 ->
-  match Defs.saturate_until idx_succ idx_zero spaced_list_intersect rebuild_fuel rs P fuel e_0 with
+  match Defs.saturate_until idx_succ idx_zero idx_leb spaced_list_intersect rebuild_fuel window rs P fuel e_0 with
   | (_, e') => Semantics.egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result e'
                /\ exists i', map.extends i' i_0 /\ Semantics.egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i' e'
   end.
@@ -287,8 +293,8 @@ Proof.
   destruct (rebuild rebuild_fuel e_a) as [u_b e_b] eqn:Hrbeq.
   cbn [snd] in Hok_b, Hde.
   pose proof (proj1 (Hde i_a) Hsnd_a) as Hsnd_b.
-  pose proof (saturate_until'_sound (spaced_list_intersect:=spaced_list_intersect) (m:=m) Hlti Hlts Hltt rebuild_fuel rs P HP Hrules fuel i_a e_b Hok_b Hsnd_b) as Hsat.
-  destruct (saturate_until' idx_succ idx_zero spaced_list_intersect rebuild_fuel rs P fuel e_b) as [b e_final] eqn:Hsf.
+  pose proof (saturate_until'_sound (spaced_list_intersect:=spaced_list_intersect) (m:=m) Hlti Hlts Hltt rebuild_fuel rs P HP Hrules fuel window i_a e_b Hok_b Hsnd_b) as Hsat.
+  destruct (saturate_until' idx_succ idx_zero idx_leb spaced_list_intersect rebuild_fuel window rs P fuel e_b) as [b e_final] eqn:Hsf.
   destruct Hsat as (Hok_f & i_f & Hext_f & Hsnd_f).
   split; [exact Hok_f|]. exists i_f.
   split; [eapply map_extends_trans; [exact Hext_f | exact Hext_a] | exact Hsnd_f].


### PR DESCRIPTION
Fix a bug that was not properly performing semi-naive evaluation. Required explicitly handling the interaction between schedules and semi-naive evaluation.