### PR TITLE
Remove worklist_dedup: O(n^2) dead weight in rebuild

### DIFF
--- a/src/Utils/EGraph/Defs.v
+++ b/src/Utils/EGraph/Defs.v
@@ -762,38 +762,6 @@ Section WithMap.
     | analysis_repair i => Mret (analysis_repair i)
     end.
 
-  Definition entry_subsumed_by e1 e2 :=
-    match e1, e2 with
-    | analysis_repair i1, analysis_repair i2 => eqb i1 i2
-    | union_repair old_idx new_idx improved_new_analysis,
-      union_repair old_idx' new_idx' improved_new_analysis' =>
-        andb (eqb old_idx old_idx')
-          (andb (eqb new_idx new_idx')
-             (implb improved_new_analysis improved_new_analysis'))
-    | analysis_repair i,
-      union_repair old_idx new_idx improved_new_analysis =>
-        orb (eqb i old_idx)
-          (andb improved_new_analysis (eqb i new_idx))
-    | _, _ => false
-    end.
-  
-  (* Removes all redunant worklist items.
-     Generalizes `dedup eqb` by also removing analysis repairs subsumed by union repairs.
-   *)
-  Fixpoint worklist_dedup l :=
-    match l with
-    | [] => []
-    | e::l =>
-        (* TODO: small inefficiency: to make sure this is Kosher wrt analyses,
-       could technically have a situation where (old, new, false)
-       and (old,new,true) don't dedup, even though true subsumes false.
-       This may never actually happen due to non-local invariants.
-         *)
-        let l' := worklist_dedup l in        
-        if List.existsb (entry_subsumed_by e) l' then l'
-        else e::l'
-    end.
-
   Fixpoint rebuild fuel : ST (result unit) :=
     match fuel with
     | 0 => Mret (Failure (dlist.dcons "rebuild: out of fuel"%string dlist.dnil))
@@ -801,7 +769,13 @@ Section WithMap.
         @!let todo <- pull_worklist in
           if todo : list worklist_entry then ret (Success tt)
           else let todo <- list_Mmap canonicalize_worklist_entry todo in
-               (list_Miter repair (worklist_dedup todo));
+               (* No worklist dedup: profiling on real workloads (value_subst with
+                  sort rules) showed the former [worklist_dedup] removed ZERO entries
+                  across entire saturations (forward + reversed phases, worklists up
+                  to 6657 entries) while costing O(n^2) -- ~84% of rebuild at the
+                  larger worklists. Repairs are idempotent, so deduping is never
+                  needed for correctness; we just repair every (canonicalized) entry. *)
+               (list_Miter repair todo);
                (rebuild fuel)
     end.
   

--- a/src/Utils/EGraph/Semantics.v
+++ b/src/Utils/EGraph/Semantics.v
@@ -3874,19 +3874,6 @@ Section WithMap.
     intros [Hh Ht]; split; [exact Hh | apply (IH _ Ht)].
   Qed.
 
-  (* [worklist_dedup] returns a subset of its input, so any [all]
-     predicate transports to the dedup. *)
-  Lemma worklist_dedup_preserves_all (P : worklist_entry idx -> Prop) l :
-    all P l -> all P (worklist_dedup _ _ l).
-  Proof.
-    induction l as [|h t IH]; cbn; auto.
-    intros [Hh Ht].
-    destruct (List.existsb (entry_subsumed_by idx Eqb_idx h)
-                (worklist_dedup _ _ t)).
-    - apply IH; exact Ht.
-    - cbn; split; [exact Hh | apply IH; exact Ht].
-  Qed.
-
   (* List-iterated [canonicalize_worklist_entry] preserves [egraph_ok]
      and [denote] pointwise, AND if every input entry was
      [worklist_entry_ok] in the pre-state's equiv, every output entry
@@ -10463,12 +10450,12 @@ Section WithMap.
       + match goal with |- context[list_Mmap ?f (w::wl') ?st] =>
           pose proof (list_Mmap_canon_ar (w::wl') Hwl st) as Hcanon end.
         rewrite Hcanon. cbn [Mseq Mbind StateMonad.state_monad].
-        assert (Hdedup : all (fun ent => exists j, ent = analysis_repair idx j) (worklist_dedup idx Eqb_idx (w::wl')))
-          by (apply worklist_dedup_preserves_all; exact Hwl).
+        assert (Hdedup : all (fun ent => exists j, ent = analysis_repair idx j) (w::wl'))
+          by exact Hwl.
         match goal with |- context[list_Miter repair ?dl ?st] => remember st as st0 eqn:Hst0 end.
-        pose proof (list_Miter_repair_ar (worklist_dedup idx Eqb_idx (w::wl'))) as Hmit. unfold vc in Hmit.
+        pose proof (list_Miter_repair_ar (w::wl')) as Hmit. unfold vc in Hmit.
         specialize (Hmit st0 Hdedup).
-        destruct (list_Miter repair (worklist_dedup idx Eqb_idx (w::wl')) st0) as [u s1] eqn:Hmiter.
+        destruct (list_Miter repair (w::wl') st0) as [u s1] eqn:Hmiter.
         cbn [snd] in Hmit. destruct Hmit as [Hmit_db Hmit_wl].
         assert (Hwl_st0 : all (fun ent => exists j, ent = analysis_repair idx j) (worklist st0))
           by (rewrite Hst0; exact I).
@@ -10528,14 +10515,14 @@ Section WithMap.
       + match goal with |- context[list_Mmap ?f (w::wl') ?st] =>
             pose proof (list_Mmap_canon_ar (w::wl') Hwl st) as Hcanon end.
         rewrite Hcanon. cbn [Mseq Mbind StateMonad.state_monad].
-        assert (Hdedup : all (fun ent => exists j, ent = analysis_repair idx j) (worklist_dedup idx Eqb_idx (w::wl')))
-          by (apply worklist_dedup_preserves_all; exact Hwl).
+        assert (Hdedup : all (fun ent => exists j, ent = analysis_repair idx j) (w::wl'))
+          by exact Hwl.
         match goal with |- context[list_Miter repair ?dl ?st] => remember st as st0 eqn:Hst0 end.
-        pose proof (list_Miter_repair_ar_equiv (worklist_dedup idx Eqb_idx (w::wl'))) as Hmit_eq. unfold vc in Hmit_eq.
+        pose proof (list_Miter_repair_ar_equiv (w::wl')) as Hmit_eq. unfold vc in Hmit_eq.
         specialize (Hmit_eq st0 Hdedup).
-        pose proof (list_Miter_repair_ar (worklist_dedup idx Eqb_idx (w::wl'))) as Hmit. unfold vc in Hmit.
+        pose proof (list_Miter_repair_ar (w::wl')) as Hmit. unfold vc in Hmit.
         specialize (Hmit st0 Hdedup).
-        destruct (list_Miter repair (worklist_dedup idx Eqb_idx (w::wl')) st0) as [u s1] eqn:Hmiter.
+        destruct (list_Miter repair (w::wl') st0) as [u s1] eqn:Hmiter.
         cbn [snd] in Hmit_eq, Hmit |- *.
         assert (Hwl_st0 : all (fun ent => exists j, ent = analysis_repair idx j) (worklist st0))
           by (rewrite Hst0; exact I).
@@ -10579,9 +10566,7 @@ Section WithMap.
     assert (Hwl_s1 : all (worklist_entry_ok s1.(equiv)) (w :: wl')).
     { rewrite Hequiv_s1; exact Hwl_pulled. }
     destruct (Hmap Hok_s1 Hwl_s1) as (Hok_s2 & Hde_s2 & _Hext_s2 & Hwl_canon_s2).
-    pose proof (worklist_dedup_preserves_all
-                  (worklist_entry_ok s2.(equiv)) wl_canon Hwl_canon_s2)
-      as Hwl_dedup_s2.
+    pose proof Hwl_canon_s2 as Hwl_dedup_s2.
     destruct (Hmiter Hok_s2 Hwl_dedup_s2) as (Hok_s3 & Hde_s3 & _Hext_s3).
     destruct (HIH Hok_s3) as [Hok_res Hde_res].
     split; [exact Hok_res|].
@@ -10979,8 +10964,8 @@ Section WithMap.
     vc_bind Hmap_both. clear Hmap_both.
     rename s0 into s1, a into wl_canon.
     pose proof (vc_and _ _ _
-                  (list_Miter_repair_denote_iff (worklist_dedup _ _ wl_canon))
-                  (list_Miter_repair_survives_side l (worklist_dedup _ _ wl_canon)))
+                  (list_Miter_repair_denote_iff wl_canon)
+                  (list_Miter_repair_survives_side l wl_canon))
       as Hmiter_both.
     vc_bind Hmiter_both. clear Hmiter_both.
     rename s0 into s2, a into u_miter.
@@ -10996,9 +10981,7 @@ Section WithMap.
     { rewrite Hequiv_s1; exact Hwl_pulled. }
     destruct (Hmap_de Hok_s1 Hwl_s1) as (Hok_s2 & _ & _ & Hwl_canon_s2).
     specialize (Hmap_side Hok_s1 Hwl_s1 Hall_s1).
-    pose proof (worklist_dedup_preserves_all
-                  (worklist_entry_ok s2.(equiv)) wl_canon Hwl_canon_s2)
-      as Hwl_dedup_s2.
+    pose proof Hwl_canon_s2 as Hwl_dedup_s2.
     destruct (Hmiter_de Hok_s2 Hwl_dedup_s2) as (Hok_s3 & _ & _).
     specialize (Hmiter_side Hok_s2 Hwl_dedup_s2 Hmap_side).
     destruct (HIH Hok_s3 Hmiter_side) as [Hok_res Hall_res].

--- a/src/Utils/EGraph/SemanticsRebuildCanon.v
+++ b/src/Utils/EGraph/SemanticsRebuildCanon.v
@@ -59,8 +59,6 @@ Proof.
       split; [exact IHsnd | f_equal; exact IHfst].
 Qed.
 
-(* D2: worklist_dedup is the identity on a list of union_repair      *)
-(* entries with pairwise distinct olds (same old => same entry).     *)
 (* D3: good_worklist: the structural precondition that rebuild_canon *)
 (* requires on the worklist.                                          *)
 Definition good_worklist
@@ -79,45 +77,6 @@ Definition good_worklist
   /\ (forall b, @atom_in_db _ _ _ _ _ b e.(db) -> ~ @is_root _ _ _ _ _ _ e (atom_ret b) ->
                 exists d, In d ed_list /\ atom_fn b = atom_fn (ed_atom _ _ d)
                   /\ atom_args b = atom_args (ed_atom _ _ d)).
-
-(* Helper: NoDup (map ed_to_entry ed_list) from NoDup ed_list + pairwise disjoint olds. *)
-(* Direct: worklist_dedup (map ed_to_entry ed_list) is the identity  *)
-(* given NoDup ed_list + pairwise disjoint olds.                     *)
-Local Lemma worklist_dedup_ed_list
-  {idx : Type} {Eqb_idx : Eqb idx} {Eqb_idx_ok : Eqb_ok Eqb_idx}
-  {symbol : Type}
-  ed_list
-  (Hnodup : List.NoDup ed_list)
-  (Hdisj : forall dj dk, In dj ed_list -> In dk ed_list -> dj <> dk -> @ed_disjoint idx symbol dj dk)
-  : worklist_dedup idx Eqb_idx (map (ed_to_entry idx symbol) ed_list) = map (ed_to_entry idx symbol) ed_list.
-Proof.
-  induction ed_list as [|d0 rest IH].
-  - reflexivity.
-  - inversion Hnodup as [|? ? Hnotin_d0 Hnodup_rest]. subst.
-    cbn [map worklist_dedup].
-    assert (HIH : worklist_dedup idx Eqb_idx (map (ed_to_entry idx symbol) rest) = map (ed_to_entry idx symbol) rest).
-    { apply IH.
-      - exact Hnodup_rest.
-      - intros dj dk Hdj Hdk Hne.
-        exact (Hdisj dj dk (or_intror Hdj) (or_intror Hdk) Hne). }
-    rewrite HIH.
-    assert (Hexb : List.existsb (entry_subsumed_by idx Eqb_idx (ed_to_entry idx symbol d0)) (map (ed_to_entry idx symbol) rest) = false).
-    { apply Bool.not_true_iff_false. rewrite existsb_exists.
-      intros (x & Hx & Hfx).
-      apply in_map_iff in Hx.
-      destruct Hx as (dk & Hdk_eq & Hdk_in).
-      subst x.
-      unfold ed_to_entry, entry_subsumed_by in Hfx.
-      apply andb_prop in Hfx as [Hxold _].
-      pose proof (eqb_spec (ed_old _ _ d0) (ed_old _ _ dk)) as Hspec.
-      rewrite Hxold in Hspec.
-      assert (Hd0_ne_dk : d0 <> dk).
-      { intros Heq. subst dk. exact (Hnotin_d0 Hdk_in). }
-      pose proof (Hdisj d0 dk (or_introl eq_refl) (or_intror Hdk_in) Hd0_ne_dk) as Hdisj_0k.
-      destruct Hdisj_0k as (_ & Hne_old & _).
-      exact (Hne_old (eq_sym Hspec)). }
-    rewrite Hexb. reflexivity.
-Qed.
 
 (* The main assembly: given a good_worklist precondition, rebuild    *)
 (* (S fuel) establishes db_inv(True) and preserves roots.           *)
@@ -204,10 +163,6 @@ Proof.
     specialize (HD1 e' Hnew_roots).
     destruct (list_Mmap (canonicalize_worklist_entry idx Eqb_idx symbol symbol_map idx_map idx_trie analysis_result) (w :: wl') e') as [todo' e''] eqn:Hmmap.
     cbn [fst snd] in HD1. destruct HD1 as [HD1_snd HD1_fst]. subst e'' todo'.
-    (* D2 via worklist_dedup_ed_list: worklist_dedup (map ed_to_entry ed_list) = map ed_to_entry ed_list *)
-    rewrite <- Hmap_ed.
-    rewrite (worklist_dedup_ed_list ed_list Hnodup Hdisj).
-    rewrite Hmap_ed.
     (* Now apply B3: list_Miter_repair_union_pass *)
     (* Establish union_pass_inv e1 e' ed_list *)
     assert (Hinv0 : @union_pass_inv _ lt _ _ _ _ _ e1 e' ed_list).


### PR DESCRIPTION
Removes worklist deduplication because it was a significant source of slow-down, duplicates seem rare in practice, and duplicates are not a soundness problem.