### PR TITLE
Clean up e-graph lemmas.

### DIFF
--- a/src/Pyrosome/Tools/EGraph/AdapterGlue.v
+++ b/src/Pyrosome/Tools/EGraph/AdapterGlue.v
@@ -395,7 +395,7 @@ Section WithVar.
                     V_trie V_trie_ok unit HX
                     (lang_model l)
                     (@Theorems.lang_model_ok V V_Eqb V_Eqb_ok sort_of l Hsof Hwf)
-                    (fun _ => True) rf)
+                    rf)
         as Hvc_rb.
       unfold vc in Hvc_rb.
       specialize (Hvc_rb (snd (add_ctx succ sort_of l false false c (empty_egraph V_default X)))).
@@ -468,7 +468,7 @@ Section WithVar.
                     V_trie V_trie_ok unit HX
                     (lang_model l)
                     (@Theorems.lang_model_ok V V_Eqb V_Eqb_ok sort_of l Hsof Hwf)
-                    (fun _ => True) rf)
+                    rf)
         as Hvc_rb2.
       unfold vc in Hvc_rb2.
       specialize (Hvc_rb2 e_open).
@@ -1437,7 +1437,7 @@ Section WithVar.
                     V_trie V_trie_ok unit HX
                     (lang_model l)
                     (@Theorems.lang_model_ok V V_Eqb V_Eqb_ok sort_of l Hsof Hwf)
-                    (fun _ => True) rf)
+                    rf)
         as Hvc_rb2.
       unfold vc in Hvc_rb2.
       specialize (Hvc_rb2 e_open).
@@ -1989,7 +1989,7 @@ Section WithVar.
                     V_trie V_trie_ok unit HX
                     (lang_model l)
                     (@Theorems.lang_model_ok V V_Eqb V_Eqb_ok sort_of l Hsof Hwf)
-                    (fun _ => True) rf)
+                    rf)
         as Hvc_rb.
       unfold vc in Hvc_rb.
       specialize (Hvc_rb e_open).
@@ -2118,7 +2118,7 @@ Section WithVar.
                     V_trie V_trie_ok unit HX
                     (lang_model l)
                     (@Theorems.lang_model_ok V V_Eqb V_Eqb_ok sort_of l Hsof Hwf)
-                    (fun _ => True) rf)
+                    rf)
         as Hvc_rb.
       unfold vc in Hvc_rb. specialize (Hvc_rb e_union). cbn [snd] in Hvc_rb.
       specialize (Hvc_rb Hvc_union_ok).
@@ -2807,7 +2807,7 @@ Section WithVar.
                     V_trie V_trie_ok unit HX
                     (lang_model l)
                     (@Theorems.lang_model_ok V V_Eqb V_Eqb_ok sort_of l Hsof Hwf)
-                    (fun _ => True) rf)
+                    rf)
         as Hvc_rb.
       unfold vc in Hvc_rb.
       specialize (Hvc_rb e_open).
@@ -2925,7 +2925,7 @@ Section WithVar.
                     V_trie V_trie_ok unit HX
                     (lang_model l)
                     (@Theorems.lang_model_ok V V_Eqb V_Eqb_ok sort_of l Hsof Hwf)
-                    (fun _ => True) rf)
+                    rf)
         as Hvc_rb.
       unfold vc in Hvc_rb. specialize (Hvc_rb e_union). cbn [snd] in Hvc_rb.
       specialize (Hvc_rb Hvc_union_ok).

--- a/src/Pyrosome/Tools/EGraph/AddCtxInversion.v
+++ b/src/Pyrosome/Tools/EGraph/AddCtxInversion.v
@@ -133,11 +133,11 @@ Section WithVar.
         pose proof (@rebuild_canon V V_Eqb V_Eqb_ok lt succ V_default
                       V V_Eqb V_Eqb_ok V_map V_map_ok V_map V_map_ok V_trie V_trie_ok
                       X _ lang_model (lang_model_ok l Hsof Hwf)
-                      fuel e1 ed_list Hok Hgwl) as [HdbT [Hmono _] ].
+                      fuel ed_list e1 Hok Hgwl) as [HdbT [Hmono _] ].
         eapply (@L_survive_canonical' V V_Eqb V_Eqb_ok lt succ V_default
                       V V_Eqb V_Eqb_ok V_map V_map_ok V_map V_map_ok V_trie V_trie_ok
                       X _ lang_model (lang_model_ok l Hsof Hwf)
-                      (S fuel) e1 a).
+                      (S fuel) a e1).
         + exact Hok.
         + exact Hup.
         + exact HdbT.
@@ -272,7 +272,7 @@ Section WithVar.
       pose proof (@rebuild_canon V V_Eqb V_Eqb_ok lt succ V_default
                     V V_Eqb V_Eqb_ok V_map V_map_ok V_map V_map_ok V_trie V_trie_ok
                     X _ lang_model (lang_model_ok l Hsof Hwf)
-                    fuel e1 ed_list Hok1 Hgwl) as (HdbT & Hmono & Hrev).
+                    fuel ed_list e1 Hok1 Hgwl) as (HdbT & Hmono & Hrev).
       (* --- canonicalizing survival --- *)
       pose proof (rebuild_survives_canonical e1 (S fuel) Hok1 (ex_intro _ _ Hgwl) Hsucc) as Hsurv.
       (* --- build Hsurv_exact from Hsurv (for use with atom_tree_sort_survives) --- *)
@@ -388,7 +388,7 @@ Section WithVar.
       pose proof (@rebuild_canon V V_Eqb V_Eqb_ok lt succ V_default
                     V V_Eqb V_Eqb_ok V_map V_map_ok V_map V_map_ok V_trie V_trie_ok
                     X _ lang_model (lang_model_ok l Hsof Hwf)
-                    fuel e1 ed_list Hok1 Hgwl) as (HdbT & Hmono & Hrev).
+                    fuel ed_list e1 Hok1 Hgwl) as (HdbT & Hmono & Hrev).
       unfold ain, Semantics.atom_in_egraph in Hb. fold eF in Hb.
       destruct (Hrev b Hb) as (a & Ha_e1_db & Hafn & Haargs).
       assert (Ha_e1_in : ain a e1) by (unfold ain, Semantics.atom_in_egraph; exact Ha_e1_db).
@@ -606,7 +606,7 @@ Section WithVar.
         pose proof (@alloc_opaque_rank_zero V V_Eqb V_Eqb_ok lt succ V V_map V_map V_map_ok V_trie X HX lt_asymmetric lt_succ lt_trans) as Halloc.
         pose proof (@alloc_opaque_egraph_ok V V_Eqb V_Eqb_ok lt succ V V_map V_map V_map_ok V_trie X HX lt_asymmetric lt_succ lt_trans) as Halloc_eg.
         pose proof (@alloc_opaque_parents_keys_in_equiv V V_Eqb V_Eqb_ok lt succ V V_map V_map V_map_ok V_trie X HX lt_asymmetric lt_succ lt_trans) as Halloc_pke.
-        pose proof (@alloc_opaque_analyses_cover V V_Eqb V_Eqb_ok lt succ V V_map V_map V_map_ok V_trie X HX lt_asymmetric lt_succ lt_trans) as Halloc_ac.
+        pose proof (@alloc_opaque_analyses_cover V V_Eqb V_Eqb_ok lt succ V V_map V_map V_map_ok V_trie X HX) as Halloc_ac.
         unfold vc in Halloc, Halloc_eg, Halloc_pke, Halloc_ac.
         specialize (Halloc e_sort). specialize (Halloc_eg e_sort). specialize (Halloc_pke e_sort). specialize (Halloc_ac e_sort).
         destruct (alloc_opaque V succ V V_map V_map V_trie X e_sort) as [x' e_alloc] eqn:Heq_alloc.
@@ -940,7 +940,7 @@ Section WithVar.
         pose proof (@alloc_opaque_rank_zero V V_Eqb V_Eqb_ok lt succ V V_map V_map V_map_ok V_trie X HX lt_asymmetric lt_succ lt_trans) as Halloc.
         pose proof (@alloc_opaque_egraph_ok V V_Eqb V_Eqb_ok lt succ V V_map V_map V_map_ok V_trie X HX lt_asymmetric lt_succ lt_trans) as Halloc_eg.
         pose proof (@alloc_opaque_parents_keys_in_equiv V V_Eqb V_Eqb_ok lt succ V V_map V_map V_map_ok V_trie X HX lt_asymmetric lt_succ lt_trans) as Halloc_pke.
-        pose proof (@alloc_opaque_analyses_cover V V_Eqb V_Eqb_ok lt succ V V_map V_map V_map_ok V_trie X HX lt_asymmetric lt_succ lt_trans) as Halloc_ac.
+        pose proof (@alloc_opaque_analyses_cover V V_Eqb V_Eqb_ok lt succ V V_map V_map V_map_ok V_trie X HX) as Halloc_ac.
         unfold vc in Halloc, Halloc_eg, Halloc_pke, Halloc_ac.
         specialize (Halloc e_sort). specialize (Halloc_eg e_sort). specialize (Halloc_pke e_sort). specialize (Halloc_ac e_sort).
         destruct (alloc_opaque V succ V V_map V_map V_trie X e_sort) as [x' e_alloc] eqn:Heq_alloc.
@@ -1190,7 +1190,7 @@ Section WithVar.
         pose proof (@alloc_opaque_rank_zero V V_Eqb V_Eqb_ok lt succ V V_map V_map V_map_ok V_trie X HX lt_asymmetric lt_succ lt_trans) as Halloc.
         pose proof (@alloc_opaque_egraph_ok V V_Eqb V_Eqb_ok lt succ V V_map V_map V_map_ok V_trie X HX lt_asymmetric lt_succ lt_trans) as Halloc_eg.
         pose proof (@alloc_opaque_parents_keys_in_equiv V V_Eqb V_Eqb_ok lt succ V V_map V_map V_map_ok V_trie X HX lt_asymmetric lt_succ lt_trans) as Halloc_pke.
-        pose proof (@alloc_opaque_analyses_cover V V_Eqb V_Eqb_ok lt succ V V_map V_map V_map_ok V_trie X HX lt_asymmetric lt_succ lt_trans) as Halloc_ac.
+        pose proof (@alloc_opaque_analyses_cover V V_Eqb V_Eqb_ok lt succ V V_map V_map V_map_ok V_trie X HX) as Halloc_ac.
         unfold vc in Halloc, Halloc_eg, Halloc_pke, Halloc_ac.
         specialize (Halloc e_inner). specialize (Halloc_eg e_inner). specialize (Halloc_pke e_inner). specialize (Halloc_ac e_inner).
         destruct (alloc_opaque V succ V V_map V_map V_trie X e_inner) as [x' e_alloc] eqn:Heq_alloc.
@@ -2345,7 +2345,7 @@ Section WithVar.
                     V V_Eqb V_Eqb_ok V_map V_map_ok V_map V_map_ok V_trie V_trie_ok
                     X HX (Theorems.lang_model V sort_of l)
                     (@Theorems.lang_model_ok V V_Eqb V_Eqb_ok sort_of l Hsof Hwf)
-                    fuel e_open ed_list Hok_open Hgwl_open) as (HdbT & Hmono & Hrev).
+                    fuel ed_list e_open Hok_open Hgwl_open) as (HdbT & Hmono & Hrev).
       destruct (Hrev b Hb) as (a & Ha_eopen_db & Hafn & Haargs).
       assert (Hafn_sof : atom_fn a = sort_of) by (rewrite Hafn; exact Hbfn).
       pose proof (@Theorems.add_open_term'_keeps_sortof V V_Eqb V_Eqb_ok V_default V_map V_map_ok
@@ -2498,7 +2498,7 @@ Section WithVar.
                     V V_Eqb V_Eqb_ok V_map V_map_ok V_map V_map_ok V_trie V_trie_ok
                     X HX (Theorems.lang_model V sort_of l)
                     (@Theorems.lang_model_ok V V_Eqb V_Eqb_ok sort_of l Hsof Hwf)
-                    fuel e_open ed_list Hok_open Hgwl_open) as (HdbT & Hmono & Hrev).
+                    fuel ed_list e_open Hok_open Hgwl_open) as (HdbT & Hmono & Hrev).
       destruct (Hrev b Hb) as (a & Ha_eopen_db & Hafn & Haargs).
       assert (Hafn_sof : atom_fn a = sort_of) by (rewrite Hafn; exact Hbfn).
       pose proof (@Theorems.add_open_term'_keeps_sortof V V_Eqb V_Eqb_ok V_default V_map V_map_ok
@@ -2707,7 +2707,7 @@ Section WithVar.
                     V V_Eqb V_Eqb_ok V_map V_map_ok V_map V_map_ok V_trie V_trie_ok
                     X HX (Theorems.lang_model V sort_of l)
                     (@Theorems.lang_model_ok V V_Eqb V_Eqb_ok sort_of l Hsof Hwf)
-                    fuel e_open ed_list Hok_open Hgwl_open) as (HdbT & Hmono & Hrev).
+                    fuel ed_list e_open Hok_open Hgwl_open) as (HdbT & Hmono & Hrev).
       destruct (Hrev b Hb) as (a & Ha_eopen_db & Hafn & Haargs).
       assert (Ha_eopen : @Semantics.atom_in_egraph V V V_map V_map V_trie X a e_open) by exact Ha_eopen_db.
       assert (Hafn_ne : atom_fn a <> sort_of) by (rewrite Hafn; exact Hbfn).
@@ -2949,7 +2949,7 @@ Section WithVar.
                     V V_Eqb V_Eqb_ok V_map V_map_ok V_map V_map_ok V_trie V_trie_ok
                     X HX (Theorems.lang_model V sort_of l)
                     (@Theorems.lang_model_ok V V_Eqb V_Eqb_ok sort_of l Hsof Hwf)
-                    fuel e_open ed_list Hok_open Hgwl_open) as (HdbT & Hmono & Hrev).
+                    fuel ed_list e_open Hok_open Hgwl_open) as (HdbT & Hmono & Hrev).
       destruct (Hrev b Hb) as (a & Ha_eopen_db & Hafn & Haargs).
       assert (Ha_eopen : @Semantics.atom_in_egraph V V V_map V_map V_trie X a e_open) by exact Ha_eopen_db.
       assert (Hafn_ne : atom_fn a <> sort_of) by (rewrite Hafn; exact Hbfn).
@@ -4028,7 +4028,7 @@ Section WithVar.
                     V V_Eqb V_Eqb_ok V_map V_map_ok V_map V_map_ok V_trie V_trie_ok
                     X HX (Theorems.lang_model V sort_of l)
                     (@Theorems.lang_model_ok V V_Eqb V_Eqb_ok sort_of l Hsof Hwf)
-                    fuel e_open ed_list Hok_open Hgwl_open) as (HdbT & Hmono & Hrev).
+                    fuel ed_list e_open Hok_open Hgwl_open) as (HdbT & Hmono & Hrev).
       destruct (Hrev b Hb) as (a & Ha_eopen_db & Hafn & Haargs).
       assert (Hafn_sof : atom_fn a = sort_of) by (rewrite Hafn; exact Hbfn).
       pose proof (@Theorems.add_open_sort'_keeps_sortof V V_Eqb V_Eqb_ok V_default V_map V_map_ok
@@ -4190,7 +4190,7 @@ Section WithVar.
                     V V_Eqb V_Eqb_ok V_map V_map_ok V_map V_map_ok V_trie V_trie_ok
                     X HX (Theorems.lang_model V sort_of l)
                     (@Theorems.lang_model_ok V V_Eqb V_Eqb_ok sort_of l Hsof Hwf)
-                    fuel e_open ed_list Hok_open Hgwl_open) as (HdbT & Hmono & Hrev).
+                    fuel ed_list e_open Hok_open Hgwl_open) as (HdbT & Hmono & Hrev).
       destruct (Hrev b Hb) as (a & Ha_eopen_db & Hafn & Haargs).
       assert (Ha_eopen : @Semantics.atom_in_egraph V V V_map V_map V_trie X a e_open) by exact Ha_eopen_db.
       assert (Hafn_ne : atom_fn a <> sort_of) by (rewrite Hafn; exact Hbfn).
@@ -4494,7 +4494,7 @@ Section WithVar.
                     V V_Eqb V_Eqb_ok V_map V_map_ok V_map V_map_ok V_trie V_trie_ok
                     X HX (Theorems.lang_model V sort_of l)
                     (@Theorems.lang_model_ok V V_Eqb V_Eqb_ok sort_of l Hsof Hwf)
-                    fuel e_open ed_list Hok_open Hgwl_open) as (HdbT & Hmono & Hrev).
+                    fuel ed_list e_open Hok_open Hgwl_open) as (HdbT & Hmono & Hrev).
       destruct (Hrev b Hb) as (a & Ha_eopen_db & Hafn & Haargs).
       assert (Hafn_sof : atom_fn a = sort_of) by (rewrite Hafn; exact Hbfn).
       pose proof (@Theorems.add_open_sort'_keeps_sortof V V_Eqb V_Eqb_ok V_default V_map V_map_ok
@@ -4657,7 +4657,7 @@ Section WithVar.
                     V V_Eqb V_Eqb_ok V_map V_map_ok V_map V_map_ok V_trie V_trie_ok
                     X HX (Theorems.lang_model V sort_of l)
                     (@Theorems.lang_model_ok V V_Eqb V_Eqb_ok sort_of l Hsof Hwf)
-                    fuel e_open ed_list Hok_open Hgwl_open) as (HdbT & Hmono & Hrev).
+                    fuel ed_list e_open Hok_open Hgwl_open) as (HdbT & Hmono & Hrev).
       destruct (Hrev b Hb) as (a & Ha_eopen_db & Hafn & Haargs).
       assert (Ha_eopen : @Semantics.atom_in_egraph V V V_map V_map V_trie X a e_open) by exact Ha_eopen_db.
       assert (Hafn_ne : atom_fn a <> sort_of) by (rewrite Hafn; exact Hbfn).

--- a/src/Pyrosome/Tools/EGraph/ReducingCong.v
+++ b/src/Pyrosome/Tools/EGraph/ReducingCong.v
@@ -415,11 +415,11 @@ Section ReducingStep.
         - rewrite (Hext _ _ Hgv); exact Hor.
         - discriminate Hor. }
       pose proof (@lang_model_ok V V_Eqb V_Eqb_ok sort_of l sort_of_fresh wfl) as Hmok.
-      pose proof (@get_analysis_preserves_ok_sound V lt V V_map V_map V_trie (option positive) (size V) lang_model x1 eb i2 Hok_eb Hsnd_eb) as Hg1.
+      pose proof (@get_analysis_preserves_ok_sound V lt V V_map V_map V_trie (option positive) (size V) lang_model x1 i2 eb Hok_eb Hsnd_eb) as Hg1.
       rewrite Hga1 in Hg1; cbn [snd] in Hg1; destruct Hg1 as [Hok_e1 Hsnd_e1].
-      pose proof (@get_analysis_preserves_ok_sound V lt V V_map V_map V_trie (option positive) (size V) lang_model x2 e1 i2 Hok_e1 Hsnd_e1) as Hg2.
+      pose proof (@get_analysis_preserves_ok_sound V lt V V_map V_map V_trie (option positive) (size V) lang_model x2 i2 e1 Hok_e1 Hsnd_e1) as Hg2.
       rewrite Hga2 in Hg2; cbn [snd] in Hg2; destruct Hg2 as [Hok_e2 Hsnd_e2].
-      pose proof (@rebuild_sound V V_Eqb V_Eqb_ok lt succ V_default V V_Eqb V_Eqb_ok V_map V_map_ok V_map V_map_ok V_trie V_trie_ok (option positive) (size V) lang_model Hmok (fun _ => True) rfuel e2 Hok_e2) as Hrbs.
+      pose proof (@rebuild_sound V V_Eqb V_Eqb_ok lt succ V_default V V_Eqb V_Eqb_ok V_map V_map_ok V_map V_map_ok V_trie V_trie_ok (option positive) (size V) lang_model Hmok rfuel e2 Hok_e2) as Hrbs.
       rewrite Hrb in Hrbs; cbn [snd] in Hrbs; destruct Hrbs as [Hok_e3 Hiff3].
       assert (Hsnd_e3 : sound i2 e3) by (apply (Hiff3 i2); exact Hsnd_e2).
       match type of Hsat with
@@ -428,18 +428,18 @@ Section ReducingStep.
       assert (HP : forall ee ii, egraph_ok ee -> sound ii ee -> egraph_ok (snd (pred ee)) /\ sound ii (snd (pred ee)))
         by (intros ee ii Hoke Hsnde; subst pred; unfold weight_less_than;
             cbn [Mbind Mret StateMonad.state_monad];
-            pose proof (@get_analysis_preserves_ok_sound V lt V V_map V_map V_trie (option positive) (size V) lang_model x1 ee ii Hoke Hsnde) as Hp1;
+            pose proof (@get_analysis_preserves_ok_sound V lt V V_map V_map V_trie (option positive) (size V) lang_model x1 ii ee Hoke Hsnde) as Hp1;
             destruct (get_analysis V V V_map V_map V_trie (option positive) x1 ee) as [a1 e1'] eqn:He1';
             cbn [snd] in Hp1; destruct Hp1 as [ Hok1 Hsnd1 ]; cbn [fst snd];
             destruct (oP_lt a1 w1);
             [ cbn [snd]; split; assumption | ];
             cbn [fst snd];
-            pose proof (@get_analysis_preserves_ok_sound V lt V V_map V_map V_trie (option positive) (size V) lang_model x2 e1' ii Hok1 Hsnd1) as Hp2;
+            pose proof (@get_analysis_preserves_ok_sound V lt V V_map V_map V_trie (option positive) (size V) lang_model x2 ii e1' Hok1 Hsnd1) as Hp2;
             destruct (get_analysis V V V_map V_map V_trie (option positive) x2 e1') as [a2 e2'] eqn:He2';
             cbn [snd] in Hp2; destruct Hp2 as [ Hok2 Hsnd2 ];
             destruct (oP_lt a2 w2);
             [ cbn [snd]; split; assumption | ];
-            pose proof (@are_unified_preserves_ok_sound V V_Eqb V_Eqb_ok lt succ V_default V V_map V_map V_map_ok V_trie (option positive) lang_model x1 x2 e2' ii Hok2 Hsnd2) as Hau;
+            pose proof (@are_unified_preserves_ok_sound V V_Eqb V_Eqb_ok lt succ V_default V V_map V_map V_map_ok V_trie (option positive) lang_model x1 x2 ii e2' Hok2 Hsnd2) as Hau;
             destruct Hau as [ Hoku Hsndu ]; split; assumption).
       pose proof (@scheduled_saturate_until_sound V V_Eqb V_Eqb_ok V_default V_map V_map_plus V_map_ok V_trie V_trie_ok succ V_leb lt lt_asymmetric lt_succ lt_trans V_map_plus_ok (option positive) (size V) spaced_list_intersect lang_model Hmok rfuel pred HP schedule Hsched sat_fuel i2 e3 Hok_e3 Hsnd_e3) as Hss.
       rewrite Hsat in Hss.
@@ -779,7 +779,7 @@ Section CongMain.
         assert (Hky : Sep.has_key y (parent (equiv g))) by (exact (interpretation_exact _ _ _ _ _ _ _ _ _ Hsndg y Hisy)).
         destruct (are_unified x y g) as [unified pf] eqn:Hau.
         destruct unified.
-        * pose proof (are_unified_eq_sound V V_Eqb V_Eqb_ok lt succ V_default V V_map V_map V_map_ok V_trie (option positive) lang_model x y g i Hokg Hsndg Hkx Hky ltac:(rewrite Hau; reflexivity)) as Hes.
+        * pose proof (are_unified_eq_sound V V_Eqb V_Eqb_ok lt succ V_default V V_map V_map V_map_ok V_trie (option positive) lang_model x y i g Hokg Hsndg Hkx Hky ltac:(rewrite Hau; reflexivity)) as Hes.
           eapply (eq_sound_to_eq_term V V_map sort_of l sort_of_fresh wfl i x y e1 e2 Hes); [ exact Hr1 | exact Hr2 ].
         * destruct (extract_weighted g efuel x) as [e1'|err1] eqn:Hex; cbn [Mbind Mret result_monad] in Hproc; [ | discriminate ].
           destruct (extract_weighted g efuel y) as [e2'|err2] eqn:Hey; cbn [Mbind Mret result_monad] in Hproc; [ | discriminate ].

--- a/src/Utils/EGraph/BuildTriesDepth.v
+++ b/src/Utils/EGraph/BuildTriesDepth.v
@@ -61,16 +61,12 @@ Section VariableFlags.
     - inversion Hnd as [|? ? Hnotin Hnd']; subst.
       cbn [filter variable_flags map].
       destruct (p qx) eqn:Hp.
-      + (* p qx = true *)
-        rewrite eqb_refl_true by exact Eqb_idx_ok.
+      + rewrite eqb_refl_true by exact Eqb_idx_ok.
         cbn. f_equal. apply IH. exact Hnd'.
-      + (* p qx = false *)
-        destruct (filter p qv') as [|cx cvs'] eqn:Hf.
-        * (* filter p qv' = [] *)
-          cbn [variable_flags]. f_equal.
+      + destruct (filter p qv') as [|cx cvs'] eqn:Hf.
+        * cbn [variable_flags]. f_equal.
           rewrite IH; [| exact Hnd']. reflexivity.
-        * (* filter p qv' = cx :: cvs' *)
-          assert (Hcx_in : In cx qv'). {
+        * assert (Hcx_in : In cx qv'). {
             assert (Hin : In cx (filter p qv')) by (rewrite Hf; left; reflexivity).
             apply filter_In in Hin. apply Hin. }
           assert (Hqx_ne_cx : qx <> cx). {

--- a/src/Utils/EGraph/QueryOpt.v
+++ b/src/Utils/EGraph/QueryOpt.v
@@ -158,12 +158,15 @@ Section WithMap.
 
   Notation union_find_ok := (union_find_ok lt).
   
-  Lemma force_uf_ok equiv x
-    : union_find_ok equiv x ->
-      union_find_ok (snd (force_uf equiv)) x.
+  Lemma force_uf_ok x
+    : vc force_uf
+        (fun equiv res =>
+           union_find_ok equiv x ->
+           union_find_ok (snd res) x).
   Proof.
     clear idx_succ.
-    unfold force_uf.
+    unfold vc, force_uf.
+    intros equiv.
     revert x equiv.
     enough (forall l x equiv,
                incl l (map.keys (parent equiv)) ->
@@ -188,13 +191,16 @@ Section WithMap.
   Qed.
 
   
-  Lemma force_uf_same_domain equiv l
-    : union_find_ok equiv l ->
-      forall x, Sep.has_key x (snd (force_uf equiv)).(parent _ _ _)
-                <-> Sep.has_key x equiv.(parent _ _ _).
+  Lemma force_uf_same_domain l
+    : vc force_uf
+        (fun equiv res =>
+           union_find_ok equiv l ->
+           forall x, Sep.has_key x (snd res).(parent _ _ _)
+                     <-> Sep.has_key x equiv.(parent _ _ _)).
   Proof.
     clear idx_succ.
-    unfold force_uf.
+    unfold vc, force_uf.
+    intros equiv.
     revert equiv.
     enough (forall l x equiv,
                incl l (map.keys (parent equiv)) ->
@@ -218,14 +224,17 @@ Section WithMap.
     eapply H; cbn; eauto.
   Qed.
   
-  Lemma force_uf_equivalent equiv roots
-    : union_find_ok equiv roots ->
-      forall i1 i2, uf_rel_PER idx (idx_map idx) (idx_map nat)
-                      (snd (force_uf equiv)) i1 i2
-                    <-> uf_rel_PER idx (idx_map idx) (idx_map nat) equiv i1 i2.
+  Lemma force_uf_equivalent roots
+    : vc force_uf
+        (fun equiv res =>
+           union_find_ok equiv roots ->
+           forall i1 i2, uf_rel_PER idx (idx_map idx) (idx_map nat)
+                           (snd res) i1 i2
+                         <-> uf_rel_PER idx (idx_map idx) (idx_map nat) equiv i1 i2).
   Proof.
     clear idx_succ.
-    unfold force_uf.
+    unfold vc, force_uf.
+    intros equiv.
     revert equiv.
     enough (forall l equiv,
                incl l (map.keys (parent equiv)) ->
@@ -283,12 +292,15 @@ Section WithMap.
     intros [db equiv parents epoch wl an log].
     cbn.
     intros [roots Hroots].
+    pose proof (force_uf_ok roots equiv) as Hok.
+    pose proof (force_uf_equivalent roots equiv) as Hequiv.
+    pose proof (force_uf_same_domain roots equiv) as Hdom.
     repeat split; auto.
-    - eexists. eapply force_uf_ok; eauto.
-    - eapply force_uf_equivalent; eauto.
-    - eapply force_uf_equivalent; eauto.
-    - eapply force_uf_same_domain; eauto.
-    - eapply force_uf_same_domain; eauto.
+    - eexists. eapply Hok; eauto.
+    - eapply Hequiv; eauto.
+    - eapply Hequiv; eauto.
+    - eapply Hdom; eauto.
+    - eapply Hdom; eauto.
   Qed.
   
   (*TODO: duplicated*)  
@@ -454,52 +466,58 @@ Section SequentOfStates.
       Proof using. clear. induction l; basic_goal_prep; basic_utils_crush. Qed.
 
       
-      Lemma find_does_not_touch_db a (i : instance X) a0 i0
-        : find a i = (a0, i0) ->
-          db i = db i0.
+      Lemma find_does_not_touch_db a
+        : vc (find a : state (instance X) idx)
+            (fun i res => db i = db (snd res)).
       Proof.
         clear.
+        unfold vc; intro i.
         destruct i; unfold find; cbn.
         case_match; basic_goal_prep;
           basic_utils_crush.
       Qed.
       
-      Lemma canonicalize_does_not_touch_db a (i : instance X) a0 i0
-        : canonicalize a i = (a0, i0) ->
-          db i = db i0.
+      Lemma canonicalize_does_not_touch_db a
+        : vc (canonicalize a : state (instance X) atom)
+            (fun i res => db i = db (snd res)).
       Proof.
         clear.
+        unfold vc; intro i.
         destruct a; cbn.
-        case_match.
-        assert (db i = db i1).
+        destruct (list_Mmap find atom_args i) as [l i1] eqn:Hmap.
+        assert (db i = db i1) as Hi1.
         {
-          revert l i i1 case_match_eqn;
+          revert l i i1 Hmap;
             induction atom_args;
             basic_goal_prep.
           1: basic_utils_crush.
           case_match.
-          eapply find_does_not_touch_db in case_match_eqn0.
-          rewrite  case_match_eqn0; clear  case_match_eqn0.
+          pose proof (find_does_not_touch_db a i) as Hfd.
+          rewrite case_match_eqn in Hfd; cbn [snd] in Hfd.
+          rewrite Hfd; clear Hfd.
           case_match.
           eapply  IHatom_args in case_match_eqn0.
           congruence.
         }
-        case_match.
-        apply find_does_not_touch_db in case_match_eqn0.
-        intros; autorewrite with inversion in *; break; subst.
+        destruct (find atom_ret i1) as [r i0] eqn:Hfind.
+        pose proof (find_does_not_touch_db atom_ret i1) as Hfd.
+        rewrite Hfind in Hfd; cbn [snd] in Hfd.
+        cbn [snd].
         congruence.
       Qed.
 
       
-      Lemma remove_atom_incl (i0 : instance X) a0 i1 u
-        : db_remove a0 i0 = (u, i1) ->
-          incl (db_to_atoms (db i1)) (db_to_atoms (db i0)).
+      Lemma remove_atom_incl a0
+        : vc (db_remove a0 : state (instance X) unit)
+            (fun i0 res =>
+               incl (db_to_atoms (db (snd res))) (db_to_atoms (db i0))).
       Proof using lt symbol_map_ok idx_trie_ok Eqb_symbol_ok Eqb_symbol Eqb_idx_ok
 Eqb_idx.
         clear conclusion_eqs_final live_eqn conclusion_var_in_atoms
           conclusion_eqs_verbose conclusion_atoms conclusion_inst_dedup
           conclusion_inst assumption_atoms assumption_status assumption_val assumption_inst
           idx_zero idx_succ.
+        unfold vc; intro i0.
         unfold db_remove.
         destruct i0; cbn.
         basic_goal_prep;
@@ -585,34 +603,33 @@ Eqb_idx.
         }
       Qed.
         
-      Lemma incl_remove_atoms al (i : instance X)
-        : incl ((db_to_atoms
-                   (db
-                      (snd
-                         (list_Miter
-                            (fun a : atom => @! let a0 <- canonicalize a in (db_remove a0))
-                            al i)))))
-            (db_to_atoms
-               (db
-                  i)).
+      Lemma incl_remove_atoms al
+        : vc (list_Miter
+                (fun a : atom => @! let a0 <- canonicalize a in (db_remove a0))
+                al : state (instance X) unit)
+            (fun i res =>
+               incl (db_to_atoms (db (snd res))) (db_to_atoms (db i))).
       Proof using lt symbol_map_ok idx_trie_ok Eqb_symbol_ok Eqb_symbol Eqb_idx_ok
 Eqb_idx.
         clear conclusion_eqs_final live_eqn conclusion_var_in_atoms
           conclusion_eqs_verbose conclusion_atoms conclusion_inst_dedup
           conclusion_inst assumption_atoms assumption_status assumption_val assumption_inst
           idx_zero idx_succ.
-        revert i; induction al;
-          intros.
+        unfold vc.
+        induction al;
+          intros i.
         { cbn; eapply incl_refl. }
         {
           basic_goal_prep.
           destruct (canonicalize a i) eqn:Hc.
-          eapply canonicalize_does_not_touch_db in Hc.
-          rewrite Hc.
+          pose proof (canonicalize_does_not_touch_db a i) as Hcd.
+          rewrite Hc in Hcd; cbn [snd] in Hcd.
+          rewrite Hcd.
           case_match.
-          apply remove_atom_incl in case_match_eqn.
+          pose proof (remove_atom_incl a0 i0) as Hra.
+          rewrite case_match_eqn in Hra; cbn [snd] in Hra.
           eapply incl_tran; try eassumption.
-          clear case_match_eqn.
+          clear Hra.
           eapply IHal.
         }
       Qed.

--- a/src/Utils/EGraph/QueryOptSound.v
+++ b/src/Utils/EGraph/QueryOptSound.v
@@ -925,14 +925,15 @@ Section WithMap.
   Lemma clauses_to_instance_sub_mono
     (cs : list (Semantics.clause idx symbol))
     (sub0 : named_list idx idx)
-    (e0 : Defs.instance idx symbol symbol_map idx_map idx_trie unit)
     (z w : idx) :
-    named_list_lookup_err sub0 z = Some w ->
-    match clauses_to_instance idx_succ (analysis_result:=unit) cs sub0 e0 with
-    | (_, sub1, _) => named_list_lookup_err sub1 z = Some w
-    end.
+    vc (clauses_to_instance idx_succ (analysis_result:=unit) cs sub0)
+       (fun e0 res =>
+          named_list_lookup_err sub0 z = Some w ->
+          match res with
+          | (_, sub1, _) => named_list_lookup_err sub1 z = Some w
+          end).
   Proof.
-    revert sub0 e0.
+    unfold vc. revert sub0.
     induction cs as [|c cs IH]; intros sub0 e0 Hhit.
     - cbn. exact Hhit.
     - cbn [Semantics.clauses_to_instance list_Miter].
@@ -966,36 +967,37 @@ Section WithMap.
     (Hltt : Transitive lt) (m : model symbol) (Hm : model_ok symbol m)
     (cs : list (Semantics.clause idx symbol))
     (sub0 : named_list idx idx)
-    (e0 : Defs.instance idx symbol symbol_map idx_map idx_trie unit)
     (i : idx_map (m.(domain symbol)))
     (a_src : idx_map (m.(domain symbol))) :
-    Semantics.egraph_ok idx lt symbol symbol_map idx_map idx_trie unit e0 ->
-    Semantics.egraph_sound_for_interpretation
-      idx symbol symbol_map idx_map idx_trie unit m i e0 ->
-    (* Renaming consistency at the start. *)
-    (forall x y, In (x, y) sub0 ->
-                 forall d, map.get a_src x = Some d -> map.get i y = Some d) ->
-    (* The renaming's codomain lives in the egraph's union-find. *)
-    (forall x y, In (x, y) sub0 ->
-                 Sep.has_key y (parent (equiv e0))) ->
-    (* The source clauses are sound under a_src. *)
-    all (Semantics.clause_sound_for_model idx symbol idx_map m a_src) cs ->
-    match clauses_to_instance idx_succ (analysis_result:=unit) cs sub0 e0 with
-    | ((_, sub_final), e1) =>
-        Semantics.egraph_ok idx lt symbol symbol_map idx_map idx_trie unit e1 /\
-        exists i',
-          map.extends i' i /\
+    vc (clauses_to_instance idx_succ (analysis_result:=unit) cs sub0)
+       (fun e0 res =>
+          Semantics.egraph_ok idx lt symbol symbol_map idx_map idx_trie unit e0 ->
           Semantics.egraph_sound_for_interpretation
-            idx symbol symbol_map idx_map idx_trie unit m i' e1 /\
-          (forall x y, In (x, y) sub_final ->
-                 forall d, map.get a_src x = Some d -> map.get i' y = Some d) /\
-          (forall y d, map.get i' y = Some d ->
-                       map.get i y = Some d \/
-                       (exists x', named_list_lookup_err sub_final x' = Some y))
-    end.
+            idx symbol symbol_map idx_map idx_trie unit m i e0 ->
+          (* Renaming consistency at the start. *)
+          (forall x y, In (x, y) sub0 ->
+                       forall d, map.get a_src x = Some d -> map.get i y = Some d) ->
+          (* The renaming's codomain lives in the egraph's union-find. *)
+          (forall x y, In (x, y) sub0 ->
+                       Sep.has_key y (parent (equiv e0))) ->
+          (* The source clauses are sound under a_src. *)
+          all (Semantics.clause_sound_for_model idx symbol idx_map m a_src) cs ->
+          match res with
+          | ((_, sub_final), e1) =>
+              Semantics.egraph_ok idx lt symbol symbol_map idx_map idx_trie unit e1 /\
+              exists i',
+                map.extends i' i /\
+                Semantics.egraph_sound_for_interpretation
+                  idx symbol symbol_map idx_map idx_trie unit m i' e1 /\
+                (forall x y, In (x, y) sub_final ->
+                       forall d, map.get a_src x = Some d -> map.get i' y = Some d) /\
+                (forall y d, map.get i' y = Some d ->
+                             map.get i y = Some d \/
+                             (exists x', named_list_lookup_err sub_final x' = Some y))
+          end).
   Proof.
-    revert sub0 e0 i.
-    induction cs as [|c cs IH]; intros sub0 e0 i Hok Hsnd Hren Hsubdom Hcs.
+    revert sub0 i.
+    induction cs as [|c cs IH]; unfold vc in *; intros sub0 i e0 Hok Hsnd Hren Hsubdom Hcs.
     - cbn. split; [exact Hok|]. exists i.
       split; [intros ? ? Hk; exact Hk|].
       split; [exact Hsnd|].
@@ -1151,7 +1153,8 @@ Section WithMap.
               destruct (eqb y0 y_new) eqn:Hy0yn.
               { right. assert (Heqy0 : y0 = y_new) by exact Hy0yn_dec. subst y0.
                 exists y.
-                pose proof (clauses_to_instance_sub_mono cs ((y, y_new) :: sub0) e_unioned y y_new) as Hsm.
+                pose proof (clauses_to_instance_sub_mono cs ((y, y_new) :: sub0) y y_new) as Hsm.
+                unfold vc in Hsm. specialize (Hsm e_unioned).
                 cbn [named_list_lookup_err] in Hsm.
                 assert (Hyy : eqb y y = true) by
                   (pose proof (Eqb_idx_ok y y) as Hd;
@@ -1291,7 +1294,8 @@ Section WithMap.
               destruct (eqb y0 x_new) eqn:Hy0xn.
               { right. assert (Heqy0 : y0 = x_new) by exact Hy0xn_dec. subst y0.
                 exists x.
-                pose proof (clauses_to_instance_sub_mono cs ((x, x_new) :: sub0) e_unioned x x_new) as Hsm.
+                pose proof (clauses_to_instance_sub_mono cs ((x, x_new) :: sub0) x x_new) as Hsm.
+                unfold vc in Hsm. specialize (Hsm e_unioned).
                 cbn [named_list_lookup_err] in Hsm.
                 assert (Hxx : eqb x x = true) by
                   (pose proof (Eqb_idx_ok x x) as Hd;
@@ -1435,7 +1439,8 @@ Section WithMap.
                 destruct (eqb y0 x_new) eqn:Hy0xn.
                 { right. assert (Heqy0 : y0 = x_new) by exact Hy0xn_dec. subst y0.
                   exists x.
-                  pose proof (clauses_to_instance_sub_mono cs ((x, x_new) :: sub0) e_unioned x x_new) as Hsm.
+                  pose proof (clauses_to_instance_sub_mono cs ((x, x_new) :: sub0) x x_new) as Hsm.
+                  unfold vc in Hsm. specialize (Hsm e_unioned).
                   cbn [named_list_lookup_err] in Hsm.
                   assert (Hxx2 : eqb x x = true) by
                     (pose proof (Eqb_idx_ok x x) as Hd;
@@ -1553,7 +1558,8 @@ Section WithMap.
               destruct (eqb y0 y_new) eqn:Hy0yn.
               { right. assert (Heqy0 : y0 = y_new) by exact Hy0yn_dec. subst y0.
                 exists y.
-                pose proof (clauses_to_instance_sub_mono cs ((y, y_new) :: (x, x_new) :: sub0) e_unioned y y_new) as Hsm.
+                pose proof (clauses_to_instance_sub_mono cs ((y, y_new) :: (x, x_new) :: sub0) y y_new) as Hsm.
+                unfold vc in Hsm. specialize (Hsm e_unioned).
                 cbn [named_list_lookup_err] in Hsm.
                 assert (Hyy2 : eqb y y = true) by
                   (pose proof (Eqb_idx_ok y y) as Hd;
@@ -1565,7 +1571,8 @@ Section WithMap.
                 destruct (eqb y0 x_new) eqn:Hy0xn.
                 { right. assert (Heqy0 : y0 = x_new) by exact Hy0xn_dec. subst y0.
                   exists x.
-                  pose proof (clauses_to_instance_sub_mono cs ((y, y_new) :: (x, x_new) :: sub0) e_unioned x x_new) as Hsm.
+                  pose proof (clauses_to_instance_sub_mono cs ((y, y_new) :: (x, x_new) :: sub0) x x_new) as Hsm.
+                  unfold vc in Hsm. specialize (Hsm e_unioned).
                   cbn [named_list_lookup_err] in Hsm.
                   assert (Hyx2 : eqb x y = false) by
                     (pose proof (Eqb_idx_ok x y) as Hd;
@@ -1646,7 +1653,7 @@ Section WithMap.
                                     args' x Hall_args'1 Hx))
                      Hkout'2 Hatom2).
         destruct Hue as (Hok3 & Hsnd3 & Hmono3).
-        pose proof (IH sub2 e3 i2 Hok3 Hsnd3 Hren2
+        pose proof (IH sub2 i2 e3 Hok3 Hsnd3 Hren2
                      ltac:(intros x0 y0 Hin; apply Hmono3; exact (Hsubdom2 _ _ Hin)) Hcs')
           as HIH.
         destruct (clauses_to_instance idx_succ cs sub2 e3) as [ [u_pp sub_final] e_final ] eqn:Hci.
@@ -1667,11 +1674,13 @@ Section WithMap.
                   (rename_lookup_sub_mono out sub1 e1 x'' y0 Hx'')
                   _ Hrlo) as Hs12.
                 cbn [snd fst] in Hs12.
-                pose proof (clauses_to_instance_sub_mono cs sub2 e3 x'' y0 Hs12) as Hs2f.
+                pose proof (clauses_to_instance_sub_mono cs sub2 x'' y0) as Hs2f.
+                unfold vc in Hs2f. specialize (Hs2f e3 Hs12).
                 rewrite Hci in Hs2f. exact Hs2f. } }
             { right. destruct Hsub2 as [x'' Hx''].
               exists x''.
-              pose proof (clauses_to_instance_sub_mono cs sub2 e3 x'' y0 Hx'') as Hs2f.
+              pose proof (clauses_to_instance_sub_mono cs sub2 x'' y0) as Hs2f.
+              unfold vc in Hs2f. specialize (Hs2f e3 Hx'').
               rewrite Hci in Hs2f. exact Hs2f. } }
           { right; exact Hsub_f. } }
   Qed.
@@ -2021,27 +2030,28 @@ Section WithMap.
   Lemma rename_lookup_struct
     (Hlti : Asymmetric lt) (Hlts : forall x, lt x (idx_succ x)) (Hltt : Transitive lt)
     (x : idx) (sub : named_list idx idx)
-    (e : Defs.instance idx symbol symbol_map idx_map idx_trie unit)
     (roots : list idx) :
-    union_find_ok lt (equiv e) roots ->
-    (forall a b y, named_list_lookup_err sub a = Some y ->
-                   named_list_lookup_err sub b = Some y -> a = b) ->
-    (forall a y, named_list_lookup_err sub a = Some y -> Sep.has_key y (parent (equiv e))) ->
-    match rename_lookup idx Eqb_idx idx_succ symbol symbol_map idx_map idx_trie unit x sub e with
-    | (x', sub', e') =>
-        (exists roots', union_find_ok lt (equiv e') roots') /\
-        (forall a b y, named_list_lookup_err sub' a = Some y ->
-                       named_list_lookup_err sub' b = Some y -> a = b) /\
-        (forall a y, named_list_lookup_err sub' a = Some y -> Sep.has_key y (parent (equiv e'))) /\
-        (forall a y, named_list_lookup_err sub a = Some y -> named_list_lookup_err sub' a = Some y) /\
-        named_list_lookup_err sub' x = Some x' /\
-        Sep.has_key x' (parent (equiv e')) /\
-        db e' = db e /\
-        worklist e' = worklist e /\
-        (forall z, Sep.has_key z (parent (equiv e)) -> Sep.has_key z (parent (equiv e')))
-    end.
+    vc (rename_lookup idx Eqb_idx idx_succ symbol symbol_map idx_map idx_trie unit x sub)
+       (fun e res =>
+          union_find_ok lt (equiv e) roots ->
+          (forall a b y, named_list_lookup_err sub a = Some y ->
+                         named_list_lookup_err sub b = Some y -> a = b) ->
+          (forall a y, named_list_lookup_err sub a = Some y -> Sep.has_key y (parent (equiv e))) ->
+          match res with
+          | (x', sub', e') =>
+              (exists roots', union_find_ok lt (equiv e') roots') /\
+              (forall a b y, named_list_lookup_err sub' a = Some y ->
+                             named_list_lookup_err sub' b = Some y -> a = b) /\
+              (forall a y, named_list_lookup_err sub' a = Some y -> Sep.has_key y (parent (equiv e'))) /\
+              (forall a y, named_list_lookup_err sub a = Some y -> named_list_lookup_err sub' a = Some y) /\
+              named_list_lookup_err sub' x = Some x' /\
+              Sep.has_key x' (parent (equiv e')) /\
+              db e' = db e /\
+              worklist e' = worklist e /\
+              (forall z, Sep.has_key z (parent (equiv e)) -> Sep.has_key z (parent (equiv e')))
+          end).
   Proof.
-    intros Huf Hinj Hdom.
+    unfold vc; intro e. cbn beta. intros Huf Hinj Hdom.
     unfold rename_lookup.
     destruct (named_list_lookup_err sub x) as [x'|] eqn:Hlook.
     - (* HIT: rename_lookup returns (x', sub, e) *)
@@ -2160,9 +2170,11 @@ Section WithMap.
       { intros z Hz. exact Hz. }
     - (* cons a args0 *)
       cbn [list_Mmap].
-      pose proof (rename_lookup_struct Hlti Hlts Hltt a sub e roots Huf Hinj Hdom) as Hrl.
+      pose proof (rename_lookup_struct Hlti Hlts Hltt a sub roots) as Hrl.
+      unfold vc in Hrl. specialize (Hrl e).
       destruct (rename_lookup idx Eqb_idx idx_succ symbol symbol_map idx_map idx_trie unit
                   a sub e) as [ [a' sub1] e1 ] eqn:Hrla.
+      specialize (Hrl Huf Hinj Hdom).
       destruct Hrl as (Huf1_ex & Hinj1 & Hdom1 & Hext1 & Hlook1 & Hka'1 & Hdb1 & Hwl1 & Hmono1).
       destruct Huf1_ex as [roots1 Huf1].
       cbn -[rename_lookup list_Mmap] in *.
@@ -2242,30 +2254,31 @@ Section WithMap.
   Lemma rename_atom_struct
     (Hlti : Asymmetric lt) (Hlts : forall x, lt x (idx_succ x)) (Hltt : Transitive lt)
     (a : atom) (sub : named_list idx idx)
-    (e : Defs.instance idx symbol symbol_map idx_map idx_trie unit)
     (roots : list idx) :
-    union_find_ok lt (equiv e) roots ->
-    (forall a0 b y, named_list_lookup_err sub a0 = Some y ->
-                    named_list_lookup_err sub b = Some y -> a0 = b) ->
-    (forall a0 y, named_list_lookup_err sub a0 = Some y -> Sep.has_key y (parent (equiv e))) ->
-    match rename_atom idx Eqb_idx idx_succ symbol symbol_map idx_map idx_trie unit a sub e with
-    | (a', sub', e') =>
-        (exists roots', union_find_ok lt (equiv e') roots') /\
-        (forall a0 b y, named_list_lookup_err sub' a0 = Some y ->
-                        named_list_lookup_err sub' b = Some y -> a0 = b) /\
-        (forall a0 y, named_list_lookup_err sub' a0 = Some y -> Sep.has_key y (parent (equiv e'))) /\
-        (forall z y, named_list_lookup_err sub z = Some y -> named_list_lookup_err sub' z = Some y) /\
-        atom_fn a' = atom_fn a /\
-        atom_args a' = map (named_list_lookup default sub') (atom_args a) /\
-        atom_ret a' = named_list_lookup default sub' (atom_ret a) /\
-        (forall z, In z (atom_ret a :: atom_args a) ->
-                   exists y, named_list_lookup_err sub' z = Some y) /\
-        db e' = db e /\
-        worklist e' = worklist e /\
-        (forall z, Sep.has_key z (parent (equiv e)) -> Sep.has_key z (parent (equiv e')))
-    end.
+    vc (rename_atom idx Eqb_idx idx_succ symbol symbol_map idx_map idx_trie unit a sub)
+       (fun e res =>
+          union_find_ok lt (equiv e) roots ->
+          (forall a0 b y, named_list_lookup_err sub a0 = Some y ->
+                          named_list_lookup_err sub b = Some y -> a0 = b) ->
+          (forall a0 y, named_list_lookup_err sub a0 = Some y -> Sep.has_key y (parent (equiv e))) ->
+          match res with
+          | (a', sub', e') =>
+              (exists roots', union_find_ok lt (equiv e') roots') /\
+              (forall a0 b y, named_list_lookup_err sub' a0 = Some y ->
+                              named_list_lookup_err sub' b = Some y -> a0 = b) /\
+              (forall a0 y, named_list_lookup_err sub' a0 = Some y -> Sep.has_key y (parent (equiv e'))) /\
+              (forall z y, named_list_lookup_err sub z = Some y -> named_list_lookup_err sub' z = Some y) /\
+              atom_fn a' = atom_fn a /\
+              atom_args a' = map (named_list_lookup default sub') (atom_args a) /\
+              atom_ret a' = named_list_lookup default sub' (atom_ret a) /\
+              (forall z, In z (atom_ret a :: atom_args a) ->
+                         exists y, named_list_lookup_err sub' z = Some y) /\
+              db e' = db e /\
+              worklist e' = worklist e /\
+              (forall z, Sep.has_key z (parent (equiv e)) -> Sep.has_key z (parent (equiv e')))
+          end).
   Proof.
-    intros Huf Hinj Hdom.
+    unfold vc; intro e. cbn beta. intros Huf Hinj Hdom.
     destruct a as [f args out].
     unfold rename_atom.
     cbn [atom_fn atom_args atom_ret].
@@ -2281,12 +2294,13 @@ Section WithMap.
     destruct HF2 as (Huf1_ex & Hinj1 & Hdom1 & Hext1 & Hmap1 & Hdb1 & Hwl1 & Hmono1).
     destruct Huf1_ex as [roots1 Huf1].
     cbn [fst snd uncurry].
-    pose proof (rename_lookup_struct Hlti Hlts Hltt out sub1 e1 roots1
-                  Huf1 Hinj1 Hdom1) as HF1.
+    pose proof (rename_lookup_struct Hlti Hlts Hltt out sub1 roots1) as HF1.
+    unfold vc in HF1. specialize (HF1 e1).
     set (RL := rename_lookup idx Eqb_idx idx_succ symbol symbol_map idx_map idx_trie
                  unit out sub1 e1) in *.
     destruct RL as [ [out' sub2] e2 ] eqn:Hout_eq.
     cbn [fst snd] in HF1.
+    specialize (HF1 Huf1 Hinj1 Hdom1).
     destruct HF1 as (Huf2_ex & Hinj2 & Hdom2 & Hext2 & Hlook2 & Hkout & Hdb2 & Hwl2 & Hmono2).
     cbn [fst snd uncurry atom_fn atom_args atom_ret].
     (* Result atom is Build_atom f args' out', sub'=sub2, e'=e2 *)
@@ -2370,14 +2384,15 @@ Section WithMap.
   (* Helper to get parent_closed from rename_atom chain *)
   (* The key theorem: with strengthened invariant *)
   Lemma force_equiv_preserves_sound (m : model symbol)
-    (i : idx_map (m.(domain symbol)))
-    (e : instance) :
-    (exists roots, union_find_ok lt (equiv e) roots) ->
-    Semantics.egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie unit m i e ->
-    Semantics.egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie unit m i
-      (snd (force_equiv idx Eqb_idx symbol symbol_map idx_map idx_trie (X:=unit) e)).
+    (i : idx_map (m.(domain symbol))) :
+    vc (force_equiv idx Eqb_idx symbol symbol_map idx_map idx_trie (X:=unit))
+      (fun e res =>
+         (exists roots, union_find_ok lt (equiv e) roots) ->
+         Semantics.egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie unit m i e ->
+         Semantics.egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie unit m i
+           (snd res)).
   Proof.
-    intros Huf Hsnd.
+    unfold vc; intro e; cbn beta. intros Huf Hsnd.
     eapply Semantics.fields_preserved_sound_for_interpretation; [exact Hsnd|].
     pose proof (@force_equiv_sound idx Eqb_idx Eqb_idx_ok lt symbol symbol_map idx_map idx_map_ok idx_trie unit) as Hfe.
     unfold vc in Hfe.
@@ -2659,18 +2674,20 @@ Section WithMap.
     (Hlti : Asymmetric lt) (Hlts : forall x, lt x (idx_succ x)) (Hltt : Transitive lt)
     (atoms_all : list atom)
     (Huniq : NoDup (map (fun a => (atom_fn a, atom_args a)) atoms_all)) :
-    forall (Pl todo : list atom) (sub : named_list idx idx)
-      (e : Defs.instance idx symbol symbol_map idx_map idx_trie unit) (roots : list idx),
-    atoms_all = Pl ++ todo ->
-    union_find_ok lt (equiv e) roots ->
-    rename_inv Pl sub e ->
-    match clauses_to_instance idx_succ (analysis_result:=unit) (map atom_clause todo) sub e with
-    | (_, sub1, e1) =>
-        exists roots1, union_find_ok lt (equiv e1) roots1 /\ rename_inv (Pl ++ todo) sub1 e1
-    end.
+    forall (Pl todo : list atom) (sub : named_list idx idx) (roots : list idx),
+    vc (clauses_to_instance idx_succ (analysis_result:=unit) (map atom_clause todo) sub)
+       (fun e res =>
+          atoms_all = Pl ++ todo ->
+          union_find_ok lt (equiv e) roots ->
+          rename_inv Pl sub e ->
+          match res with
+          | (_, sub1, e1) =>
+              exists roots1, union_find_ok lt (equiv e1) roots1 /\ rename_inv (Pl ++ todo) sub1 e1
+          end).
   Proof.
     intros Pl todo. revert Pl.
-    induction todo as [|a todo0 IH]; intros Pl sub e roots Hsplit Huf Hinv.
+    induction todo as [|a todo0 IH]; intros Pl sub roots;
+      unfold vc; intro e; cbn beta; intros Hsplit Huf Hinv.
     - (* BASE: todo = [] *)
       cbn [map clauses_to_instance list_Miter Mret StateMonad.state_monad fst snd].
       rewrite app_nil_r.
@@ -2735,8 +2752,10 @@ Section WithMap.
       (* Destruct rename_inv *)
       destruct Hinv as (Hinj & Hdom & Hwl & Hrows & Hfwd & Hvars).
       (* Apply rename_atom_struct *)
-      pose proof (rename_atom_struct Hlti Hlts Hltt a sub e roots Huf Hinj Hdom) as Hras.
+      pose proof (rename_atom_struct Hlti Hlts Hltt a sub roots) as Hras.
+      unfold vc in Hras. specialize (Hras e).
       rewrite Hra in Hras.
+      specialize (Hras Huf Hinj Hdom).
       destruct Hras as (Huf'_ex & Hinj' & Hdom' & Hext & Hfn & Hargs & Hret & Hvars_a &
                         Hdbe' & Hwle' & Hmono).
       destruct Huf'_ex as [roots' Huf'].
@@ -2850,7 +2869,7 @@ Section WithMap.
           + destruct (Hvars a0 Hin0 x Hx) as [y Hy]. exists y. exact (Hext x y Hy).
           + destruct Hin0 as [<- | Hf]; [| destruct Hf]. exact (Hvars_a x Hx). }
       (* Apply IH *)
-      specialize (IH (Pl ++ [a]) sub' e'' roots').
+      unfold vc in IH. specialize (IH (Pl ++ [a]) sub' roots' e'').
       assert (Hsplit2 : atoms_all = (Pl ++ [a]) ++ todo0).
       { rewrite <- app_assoc. cbn [app]. exact Hsplit. }
       specialize (IH Hsplit2 Huf'' Hinv2).
@@ -2875,10 +2894,9 @@ Section WithMap.
     end.
   Proof.
     pose proof (clauses_to_instance_atoms_inv Hlti Hlts Hltt atoms Huniq
-                  [] atoms []
-                  (Defs.empty_egraph idx_zero unit : instance)
-                  []
-                  eq_refl) as Hmain.
+                  [] atoms [] []) as Hmain.
+    unfold vc in Hmain.
+    specialize (Hmain (Defs.empty_egraph idx_zero unit : instance) eq_refl).
     (* Prove union_find_ok lt (equiv empty_egraph) [] *)
     assert (Huf_empty : union_find_ok lt
               (equiv (Defs.empty_egraph idx_zero unit : instance)) []).
@@ -3712,13 +3730,13 @@ Section WithMap.
     rewrite Hempty in Hget. discriminate Hget.
   Qed.
 
-  Lemma hash_clause_sets : forall (a : Defs.atom nat symbol) (S : St),
-    qc_entry (snd (hash_clause idx idx_succ idx_zero symbol symbol_map idx_map a S))
-             (Defs.atom_fn a)
-             (fst (hash_clause idx idx_succ idx_zero symbol symbol_map idx_map a S))
-             (Defs.atom_args a, Defs.atom_ret a).
+  Lemma hash_clause_sets : forall (a : Defs.atom nat symbol),
+    vc (hash_clause idx idx_succ idx_zero symbol symbol_map idx_map a)
+       (fun S res =>
+          qc_entry (snd res) (Defs.atom_fn a) (fst res)
+                   (Defs.atom_args a, Defs.atom_ret a)).
   Proof.
-    intros [f args out] S.
+    intros [f args out]. unfold vc; intro S.
     unfold qc_entry.
     cbn [Defs.atom_fn Defs.atom_args Defs.atom_ret].
     destruct (hash_clause idx idx_succ idx_zero symbol symbol_map idx_map
@@ -3747,10 +3765,11 @@ Section WithMap.
   Qed.
 
   Lemma hash_clause_preserves_wf (Hlts : forall x, lt x (idx_succ x)) (Hltt : Transitive lt) :
-    forall (a : Defs.atom nat symbol) (S : St),
-      wf_qc_state S -> wf_qc_state (snd (hash_clause idx idx_succ idx_zero symbol symbol_map idx_map a S)).
+    forall (a : Defs.atom nat symbol),
+      vc (hash_clause idx idx_succ idx_zero symbol symbol_map idx_map a)
+         (fun S res => wf_qc_state S -> wf_qc_state (snd res)).
   Proof.
-    intros [f args out] S Hwf.
+    intros [f args out]. unfold vc; intro S. cbn beta. intro Hwf.
     unfold hash_clause.
     change St with (symbol_map (idx * idx_map (list nat * nat))) in *.
     cbn [fst snd].
@@ -3809,10 +3828,13 @@ Section WithMap.
   Qed.
 
   Lemma hash_clause_mono (Hlti : Asymmetric lt) :
-    forall (a : Defs.atom nat symbol) (S : St), wf_qc_state S ->
-    forall g j v, qc_entry S g j v -> qc_entry (snd (hash_clause idx idx_succ idx_zero symbol symbol_map idx_map a S)) g j v.
+    forall (a : Defs.atom nat symbol),
+    vc (hash_clause idx idx_succ idx_zero symbol symbol_map idx_map a)
+       (fun S res =>
+          wf_qc_state S ->
+          forall g j v, qc_entry S g j v -> qc_entry (snd res) g j v).
   Proof.
-    intros [f args out] S Hwf g j v (last & m & HgetSg & HgetMj).
+    intros [f args out]. unfold vc; intro S. cbn beta. intros Hwf g j v (last & m & HgetSg & HgetMj).
     unfold qc_entry.
     change St with (symbol_map (idx * idx_map (list nat * nat))) in *.
     unfold hash_clause. cbn [fst snd].
@@ -3860,38 +3882,39 @@ Section WithMap.
   Qed.
 
   Lemma list_Mmap_qc_preserves {A B} (step : A -> state St B)
-    (Hwf_step : forall a S, wf_qc_state S -> wf_qc_state (snd (step a S)))
-    (Hmono_step : forall a S, wf_qc_state S -> forall g j v, qc_entry S g j v -> qc_entry (snd (step a S)) g j v) :
-    forall (xs : list A) (S : St), wf_qc_state S ->
-      wf_qc_state (snd (list_Mmap step xs S))
-      /\ (forall g j v, qc_entry S g j v -> qc_entry (snd (list_Mmap step xs S)) g j v).
+    (Hwf_step : forall a, vc (step a) (fun S res => wf_qc_state S -> wf_qc_state (snd res)))
+    (Hmono_step : forall a, vc (step a) (fun S res => wf_qc_state S -> forall g j v, qc_entry S g j v -> qc_entry (snd res) g j v)) :
+    forall (xs : list A),
+      vc (list_Mmap step xs)
+         (fun S res =>
+            wf_qc_state S ->
+            wf_qc_state (snd res)
+            /\ (forall g j v, qc_entry S g j v -> qc_entry (snd res) g j v)).
   Proof.
-    induction xs as [|x xs' IH]; intros S Hs.
+    unfold vc in *.
+    induction xs as [|x xs' IH]; intro S; cbn beta; intro Hs.
     - cbn [list_Mmap Mbind Mret StateMonad.state_monad fst snd].
       split; [ exact Hs | intros g j v H; exact H ].
     - cbn [list_Mmap Mbind Mret StateMonad.state_monad].
+      pose proof (Hwf_step x S Hs) as Hwf1.
+      pose proof (Hmono_step x S Hs) as Hmono1.
       destruct (step x S) as [y S1] eqn:Hstep.
+      cbn [fst snd] in Hwf1, Hmono1.
+      specialize (IH S1 Hwf1).
       destruct (list_Mmap step xs' S1) as [ys S2] eqn:Hrec.
-      cbn [fst snd].
-      assert (HS1 : snd (step x S) = S1) by (rewrite Hstep; reflexivity).
-      assert (HS2 : snd (list_Mmap step xs' S1) = S2) by (rewrite Hrec; reflexivity).
-      rewrite <- HS1 in *.
-      specialize (IH (snd (step x S)) (Hwf_step x S Hs)).
-      rewrite HS2 in IH.
-      rewrite <- HS2 in IH.
+      cbn [fst snd] in IH |- *.
+      destruct IH as [IHwf IHmono].
       split.
-      + rewrite <- HS2. exact (proj1 IH).
-      + intros g j v Hentry.
-        rewrite <- HS2. apply (proj2 IH).
-        apply (Hmono_step x S Hs g j v Hentry).
+      + exact IHwf.
+      + intros g j v Hentry. apply IHmono. apply (Hmono1 g j v Hentry).
   Qed.
 
   Lemma compile_query_clause_preserves_wf (Hlts : forall x, lt x (idx_succ x)) (Hltt : Transitive lt) :
-    forall (qvs : list idx) (a : Defs.atom idx symbol) (S : St),
-      wf_qc_state S ->
-      wf_qc_state (snd (compile_query_clause idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map qvs a S)).
+    forall (qvs : list idx) (a : Defs.atom idx symbol),
+      vc (compile_query_clause idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map qvs a)
+         (fun S res => wf_qc_state S -> wf_qc_state (snd res)).
   Proof.
-    intros qvs [f args out] S Hs.
+    intros qvs [f args out]. unfold vc; intro S. cbn beta. intro Hs.
     unfold compile_query_clause.
     cbn [Mbind Mret StateMonad.state_monad].
     set (cc := {| atom_fn := f;
@@ -3901,21 +3924,21 @@ Section WithMap.
                   atom_ret := named_list_lookup 0
                      (combine (sort_by_position_in idx Eqb_idx (out :: args) qvs)
                         (seq 0 (length (sort_by_position_in idx Eqb_idx (out :: args) qvs)))) out |}).
+    pose proof (hash_clause_preserves_wf Hlts Hltt cc) as Hhcw.
+    unfold vc in Hhcw. specialize (Hhcw S).
     destruct (hash_clause idx idx_succ idx_zero symbol symbol_map idx_map cc S) as [i S'] eqn:Hhc.
-    cbn [fst snd].
-    assert (HS' : S' = snd (hash_clause idx idx_succ idx_zero symbol symbol_map idx_map cc S)).
-    { rewrite Hhc. reflexivity. }
-    rewrite HS'.
-    apply (hash_clause_preserves_wf Hlts Hltt cc S Hs).
+    cbn [fst snd] in Hhcw |- *.
+    exact (Hhcw Hs).
   Qed.
 
   Lemma compile_query_clause_mono (Hlti : Asymmetric lt) :
-    forall (qvs : list idx) (a : Defs.atom idx symbol) (S : St),
-      wf_qc_state S ->
-      forall g j v, qc_entry S g j v ->
-      qc_entry (snd (compile_query_clause idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map qvs a S)) g j v.
+    forall (qvs : list idx) (a : Defs.atom idx symbol),
+      vc (compile_query_clause idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map qvs a)
+         (fun S res =>
+            wf_qc_state S ->
+            forall g j v, qc_entry S g j v -> qc_entry (snd res) g j v).
   Proof.
-    intros qvs [f args out] S Hs g j v Hentry.
+    intros qvs [f args out]. unfold vc; intro S. cbn beta. intros Hs g j v Hentry.
     unfold compile_query_clause.
     cbn [Mbind Mret StateMonad.state_monad].
     set (cc := {| atom_fn := f;
@@ -3925,65 +3948,69 @@ Section WithMap.
                   atom_ret := named_list_lookup 0
                      (combine (sort_by_position_in idx Eqb_idx (out :: args) qvs)
                         (seq 0 (length (sort_by_position_in idx Eqb_idx (out :: args) qvs)))) out |}).
+    pose proof (hash_clause_mono Hlti cc) as Hhcm.
+    unfold vc in Hhcm. specialize (Hhcm S).
     destruct (hash_clause idx idx_succ idx_zero symbol symbol_map idx_map cc S) as [i S'] eqn:Hhc.
-    cbn [fst snd].
-    assert (HS' : S' = snd (hash_clause idx idx_succ idx_zero symbol symbol_map idx_map cc S)).
-    { rewrite Hhc. reflexivity. }
-    rewrite HS'.
-    apply (hash_clause_mono Hlti cc S Hs g j v Hentry).
+    cbn [fst snd] in Hhcm |- *.
+    exact (Hhcm Hs g j v Hentry).
   Qed.
 
   Lemma compile_rule_preserves_wf
     (Hlts : forall x, lt x (idx_succ x)) (Hltt : Transitive lt) (Hlti : Asymmetric lt) :
-    forall rf (r : sequent) (S : St),
-      wf_qc_state S ->
-      wf_qc_state (snd (compile_rule idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie rf r S)).
+    forall rf (r : sequent),
+      vc (compile_rule idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie rf r)
+         (fun S res => wf_qc_state S -> wf_qc_state (snd res)).
   Proof.
-    intros rf r S Hs.
+    intros rf r. unfold vc; intro S. cbn beta. intro Hs.
     unfold compile_rule.
     destruct (optimize_sequent' idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie r rf)
       as [ [assumptions conclusion_atoms] conclusion_eqs ].
     cbn [Mbind Mret StateMonad.state_monad fst snd].
     set (qvs := dedup eqb (flat_map (atom_fvs idx symbol) assumptions)).
-    destruct (list_Mmap (compile_query_clause idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map qvs)
-                assumptions S) as [qcls_ptrs S1] eqn:Hlm.
-    cbn [fst snd].
-    assert (HS1 : S1 = snd (list_Mmap
-                     (compile_query_clause idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map qvs)
-                     assumptions S)) by (rewrite Hlm; reflexivity).
-    destruct qcls_ptrs; cbn [fst snd]; rewrite HS1;
-    exact (proj1 (list_Mmap_qc_preserves
+    pose proof (list_Mmap_qc_preserves
       (compile_query_clause idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map qvs)
       (compile_query_clause_preserves_wf Hlts Hltt qvs)
       (compile_query_clause_mono Hlti qvs)
-      assumptions S Hs)).
+      assumptions) as Hlmp.
+    unfold vc in Hlmp. specialize (Hlmp S).
+    pose (res := list_Mmap (compile_query_clause idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map qvs)
+                assumptions S).
+    change (list_Mmap (compile_query_clause idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map qvs)
+                assumptions S) with res in Hlmp |- *.
+    destruct res as [qcls_ptrs S1] eqn:Hlm.
+    cbn [fst snd] in Hlmp.
+    destruct qcls_ptrs; cbn [fst snd];
+    exact (proj1 (Hlmp Hs)).
   Qed.
 
   Lemma compile_rule_mono
     (Hlts : forall x, lt x (idx_succ x)) (Hltt : Transitive lt) (Hlti : Asymmetric lt) :
-    forall rf (r : sequent) (S : St),
-      wf_qc_state S ->
-      forall g j v, qc_entry S g j v ->
-      qc_entry (snd (compile_rule idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie rf r S)) g j v.
+    forall rf (r : sequent),
+      vc (compile_rule idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie rf r)
+         (fun S res =>
+            wf_qc_state S ->
+            forall g j v, qc_entry S g j v -> qc_entry (snd res) g j v).
   Proof.
-    intros rf r S Hs g j v Hentry.
+    intros rf r. unfold vc; intro S. cbn beta. intros Hs g j v Hentry.
     unfold compile_rule.
     destruct (optimize_sequent' idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie r rf)
       as [ [assumptions conclusion_atoms] conclusion_eqs ].
     cbn [Mbind Mret StateMonad.state_monad fst snd].
     set (qvs := dedup eqb (flat_map (atom_fvs idx symbol) assumptions)).
-    destruct (list_Mmap (compile_query_clause idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map qvs)
-                assumptions S) as [qcls_ptrs S1] eqn:Hlm.
-    cbn [fst snd].
-    assert (HS1 : S1 = snd (list_Mmap
-                     (compile_query_clause idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map qvs)
-                     assumptions S)) by (rewrite Hlm; reflexivity).
-    destruct qcls_ptrs; cbn [fst snd]; rewrite HS1;
-    exact (proj2 (list_Mmap_qc_preserves
+    pose proof (list_Mmap_qc_preserves
       (compile_query_clause idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map qvs)
       (compile_query_clause_preserves_wf Hlts Hltt qvs)
       (compile_query_clause_mono Hlti qvs)
-      assumptions S Hs) g j v Hentry).
+      assumptions) as Hlmp.
+    unfold vc in Hlmp. specialize (Hlmp S).
+    pose (res := list_Mmap (compile_query_clause idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map qvs)
+                assumptions S).
+    change (list_Mmap (compile_query_clause idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map qvs)
+                assumptions S) with res in Hlmp |- *.
+    destruct res as [qcls_ptrs S1] eqn:Hlm.
+    cbn [fst snd] in Hlmp.
+    destruct qcls_ptrs; cbn [fst snd];
+    exact (proj2 (Hlmp Hs) g j v Hentry).
   Qed.
 
   (* Combined result for the outer list_Mmap (compile_rule rf) rules loop *)
@@ -4015,29 +4042,33 @@ Section WithMap.
            (assumptions : list (Defs.atom idx symbol))
            (Hsub : forall a, In a assumptions ->
                    forall x, In x (Defs.atom_ret a :: Defs.atom_args a) -> In x qvs)
-           (S0 : St) (Hwf0 : wf_qc_state S0)
-           (Qfin : St)
-           (Hmono : forall g j v,
-              qc_entry (snd (list_Mmap (compile_query_clause idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map qvs) assumptions S0)) g j v
-              -> qc_entry Qfin g j v),
-      map (fun ptr => let '(Build_erule_query_ptr _ _ f n cv_list) := ptr in
-             let '(cargs,cv) := match map.get (map_map snd Qfin) f with
-               | Some q_f => match map.get q_f n with Some c => c | None => ([],0) end
-               | None => ([],0) end in
-             Build_atom f (map (fun k => nth k cv_list idx_zero) cargs) (nth cv cv_list idx_zero))
-          (fst (list_Mmap (compile_query_clause idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map qvs) assumptions S0))
-        = assumptions.
+           ,
+      vc (list_Mmap (compile_query_clause idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map qvs) assumptions)
+        (fun S0 res =>
+           wf_qc_state S0 ->
+           forall (Qfin : St),
+             (forall g j v, qc_entry (snd res) g j v -> qc_entry Qfin g j v) ->
+             map (fun ptr => let '(Build_erule_query_ptr _ _ f n cv_list) := ptr in
+                    let '(cargs,cv) := match map.get (map_map snd Qfin) f with
+                      | Some q_f => match map.get q_f n with Some c => c | None => ([],0) end
+                      | None => ([],0) end in
+                    Build_atom f (map (fun k => nth k cv_list idx_zero) cargs) (nth cv cv_list idx_zero))
+                 (fst res)
+               = assumptions).
   Proof.
     intros qvs NDqvs assumptions.
-    induction assumptions as [|a rest IH].
-    - intros. cbn [list_Mmap Mbind Mret StateMonad.state_monad fst map]. reflexivity.
-    - intros Hsub S0 Hwf0 Qfin Hmono.
+    induction assumptions as [|a rest IH]; unfold vc in *.
+    - intros Hsub S0; cbn beta; intros Hwf0 Qfin Hmono. cbn [list_Mmap Mbind Mret StateMonad.state_monad fst map]. reflexivity.
+    - intros Hsub S0; cbn beta; intros Hwf0 Qfin Hmono.
       cbn [list_Mmap Mbind Mret StateMonad.state_monad].
       destruct (compile_query_clause idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map qvs a S0) as [ptr S1] eqn:Hcqc.
       destruct (list_Mmap (compile_query_clause idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map qvs) rest S1) as [ptrs S2] eqn:Hrec.
       cbn [fst map].
       assert (HS1_snd : S1 = snd (compile_query_clause idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map qvs a S0)) by (rewrite Hcqc; reflexivity).
-      assert (Hwf_S1 : wf_qc_state S1) by (rewrite HS1_snd; apply (compile_query_clause_preserves_wf Hlts Hltt qvs a S0 Hwf0)).
+      assert (Hwf_S1 : wf_qc_state S1).
+      { pose proof (compile_query_clause_preserves_wf Hlts Hltt qvs a) as Hcw.
+        unfold vc in Hcw. specialize (Hcw S0). rewrite Hcqc in Hcw. cbn [snd] in Hcw.
+        exact (Hcw Hwf0). }
       assert (Hmono' : forall g0 j0 v0,
           qc_entry (snd (list_Mmap (compile_query_clause idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map qvs) rest S1)) g0 j0 v0
           -> qc_entry Qfin g0 j0 v0).
@@ -4068,14 +4099,17 @@ Section WithMap.
       assert (HS1'_eq : S1' = S1).
       { injection Hcqc; intros HS _. exact HS. }
       cbn. rewrite Hptr_eq. cbn.
-      pose proof (hash_clause_sets cc S0) as Hsets.
+      pose proof (hash_clause_sets cc) as Hsets.
+      unfold vc in Hsets. specialize (Hsets S0).
       cbn [Defs.atom_fn Defs.atom_args Defs.atom_ret] in Hsets.
       assert (HS1'snd : S1' = snd (hash_clause idx idx_succ idx_zero symbol symbol_map idx_map cc S0)) by (rewrite Hhc; reflexivity).
       assert (Hi_eq : i = fst (hash_clause idx idx_succ idx_zero symbol symbol_map idx_map cc S0)) by (rewrite Hhc; reflexivity).
       rewrite <- HS1'snd, <- Hi_eq in Hsets.
       rewrite HS1'_eq in Hsets.
       assert (Hwf_S1' : wf_qc_state S1').
-      { rewrite HS1'snd. apply (hash_clause_preserves_wf Hlts Hltt cc S0 Hwf0). }
+      { rewrite HS1'snd.
+        pose proof (hash_clause_preserves_wf Hlts Hltt cc) as Hcw'.
+        unfold vc in Hcw'. specialize (Hcw' S0). exact (Hcw' Hwf0). }
       pose proof (proj2 (list_Mmap_qc_preserves
         (compile_query_clause idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map qvs)
         (compile_query_clause_preserves_wf Hlts Hltt qvs)
@@ -4256,11 +4290,13 @@ Section WithMap.
   Qed.
 
   Lemma list_Mmap_state_in :
-    forall (X S Y : Type) (f : X -> state S Y) (xs : list X) (s0 : S) (y : Y),
-      In y (fst (list_Mmap f xs s0)) ->
-      exists x s s', In x xs /\ f x s = (y, s').
+    forall (X S Y : Type) (f : X -> state S Y) (xs : list X),
+      vc (list_Mmap f xs)
+         (fun s0 res =>
+            forall (y : Y), In y (fst res) ->
+              exists x s s', In x xs /\ f x s = (y, s')).
   Proof.
-    intros X S Y f xs.
+    intros X S Y f xs. unfold vc.
     induction xs as [|x xs IH].
     - intros s0 y Hin. cbn in Hin. destruct Hin.
     - intros s0 y Hin.
@@ -4283,10 +4319,11 @@ Section WithMap.
   Qed.
 
   Lemma list_Mmap_state_length :
-    forall (Xt St0 Yt : Type) (f : Xt -> state St0 Yt) (xs : list Xt) (s0 : St0),
-      List.length (fst (list_Mmap f xs s0)) = List.length xs.
+    forall (Xt St0 Yt : Type) (f : Xt -> state St0 Yt) (xs : list Xt),
+      vc (list_Mmap f xs)
+         (fun s0 res => List.length (fst res) = List.length xs).
   Proof.
-    intros Xt St0 Yt f xs.
+    intros Xt St0 Yt f xs. unfold vc.
     induction xs as [|x xs IH]; intros s0.
     - cbn. reflexivity.
     - cbn [list_Mmap Mbind Mret StateMonad.state_monad].
@@ -4363,16 +4400,20 @@ Section WithMap.
   Lemma list_Mmap_state_in_mono
     {Y : Type}
     (step : sequent -> state St Y)
-    (Hwf : forall a (S : St), wf_qc_state S -> wf_qc_state (snd (step a S)))
-    (Hmono : forall a (S : St), wf_qc_state S -> forall g j v, qc_entry S g j v -> qc_entry (snd (step a S)) g j v) :
-    forall (xs : list sequent) (s0 : St) (y : Y),
-      wf_qc_state s0 ->
-      In y (fst (list_Mmap step xs s0)) ->
-      exists x s s', In x xs /\ step x s = (y, s') /\ wf_qc_state s /\
-        (forall g j v, qc_entry s' g j v ->
-           qc_entry (snd (list_Mmap step xs s0)) g j v).
+    (Hwf : forall a, vc (step a) (fun S res => wf_qc_state S -> wf_qc_state (snd res)))
+    (Hmono : forall a, vc (step a) (fun S res => wf_qc_state S -> forall g j v, qc_entry S g j v -> qc_entry (snd res) g j v)) :
+    forall (xs : list sequent),
+      vc (list_Mmap step xs)
+        (fun s0 res =>
+           wf_qc_state s0 ->
+           forall (y : Y),
+             In y (fst res) ->
+             exists x s s', In x xs /\ step x s = (y, s') /\ wf_qc_state s /\
+               (forall g j v, qc_entry s' g j v ->
+                  qc_entry (snd res) g j v)).
   Proof.
-    induction xs as [|x xs' IH]; intros s0 y Hwf0 Hin.
+    unfold vc in *.
+    induction xs as [|x xs' IH]; intros s0; cbn beta; intros Hwf0 y Hin.
     - cbn [list_Mmap Mbind Mret StateMonad.state_monad fst] in Hin. destruct Hin.
     - cbn [list_Mmap Mbind Mret StateMonad.state_monad] in Hin.
       destruct (step x s0) as [y0 s1] eqn:Hstep.
@@ -4382,6 +4423,7 @@ Section WithMap.
       assert (Hs1wf : wf_qc_state s1).
       { assert (Heqs1 : s1 = snd (step x s0)) by (rewrite Hstep; reflexivity).
         rewrite Heqs1. exact (Hwf x s0 Hwf0). }
+      (* Hwf is vc-shaped: [Hwf x s0] is [wf_qc_state s0 -> wf_qc_state (snd (step x s0))]. *)
       assert (Hs2 : s2 = snd (list_Mmap step xs' s1)).
       { rewrite Hrec. reflexivity. }
       assert (Hsnd_total : snd (list_Mmap step (x :: xs') s0) = s2).
@@ -4400,7 +4442,7 @@ Section WithMap.
       + (* tail case: y in ys *)
         assert (Hin' : In y (fst (list_Mmap step xs' s1))).
         { rewrite Hrec. cbn [fst]. exact Hin. }
-        specialize (IH s1 y Hs1wf Hin') as (x' & s & s' & Hxin & Hstep' & Hwfs & Hmono').
+        specialize (IH s1 Hs1wf y Hin') as (x' & s & s' & Hxin & Hstep' & Hwfs & Hmono').
         exists x', s, s'.
         split. { right. exact Hxin. }
         split. { exact Hstep'. }
@@ -4442,9 +4484,9 @@ Section WithMap.
     rewrite Hcrs in Hin.
     pose proof (list_Mmap_state_in_mono
       (compile_rule idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie rf)
-      (fun a S HS => compile_rule_preserves_wf Hlts Hltt Hlti rf a S HS)
-      (fun a S HS g j v Hentry => compile_rule_mono Hlts Hltt Hlti rf a S HS g j v Hentry)
-      rules map.empty (inl er) wf_qc_state_empty Hin)
+      (compile_rule_preserves_wf Hlts Hltt Hlti rf)
+      (compile_rule_mono Hlts Hltt Hlti rf)
+      rules map.empty wf_qc_state_empty (inl er) Hin)
       as (rule & st0 & st1 & Hrule_in & Hcompile & Hwf0 & Hmono_fin).
     exists rule, st0, st1.
     split. { exact Hrule_in. }
@@ -4711,23 +4753,22 @@ Section WithMap.
     (forall rule, In rule rules ->
        model_satisfies_rule m
          (QueryOpt.optimize_sequent idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie rule rf)) ->
-    forall (i : idx_map (Semantics.domain symbol m))
-           (e : Defs.instance idx symbol symbol_map idx_map idx_trie A),
-      egraph_ok idx lt symbol symbol_map idx_map idx_trie A e ->
-      egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie A m i e ->
-      egraph_ok idx lt symbol symbol_map idx_map idx_trie A
-        (snd (process_const_rules idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie A
-                (build_rule_set idx_succ idx_zero rf rules) e))
-      /\ exists i', map.extends i' i
-                    /\ egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie A m i'
-                         (snd (process_const_rules idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie A
-                                 (build_rule_set idx_succ idx_zero rf rules) e)).
+    forall (i : idx_map (Semantics.domain symbol m)),
+      vc (process_const_rules idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie A
+            (build_rule_set idx_succ idx_zero rf rules))
+        (fun e res =>
+           egraph_ok idx lt symbol symbol_map idx_map idx_trie A e ->
+           egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie A m i e ->
+           egraph_ok idx lt symbol symbol_map idx_map idx_trie A (snd res)
+           /\ exists i', map.extends i' i
+                         /\ egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie A m i'
+                              (snd res)).
   Proof.
-    intros Hmsr i e Hok Hsnd.
+    intros Hmsr i.
     exact (SemanticsExecConst.process_const_rules_sound (analysis_result := A) (H := HA)
-             Hlti Hlts Hltt Hm (build_rule_set idx_succ idx_zero rf rules)
+             Hlti Hlts Hltt (build_rule_set idx_succ idx_zero rf rules)
              (fun cr Hin => compile_rule_inr_const_sound m Hm rf rules cr Hmsr Hin)
-             i e Hok Hsnd).
+             i).
   Qed.
 
   (* ============================================================== *)
@@ -4768,24 +4809,26 @@ Section WithMap.
     (Hlti : Asymmetric lt) (Hlts : forall x, lt x (idx_succ x)) (Hltt : Transitive lt) :
     forall (qvs : list idx) (NDqvs : NoDup qvs)
            (assumptions : list (Defs.atom idx symbol))
-           (Hsub : forall a, In a assumptions -> forall x, In x (Defs.atom_ret a :: Defs.atom_args a) -> In x qvs)
-           (S0 : St) (Hwf0 : wf_qc_state S0)
-           (Qfin : St)
-           (Hmono : forall g j v,
-              qc_entry (snd (list_Mmap (compile_query_clause idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map qvs) assumptions S0)) g j v -> qc_entry Qfin g j v),
-      forall fsym nptr cvars,
-        In (Build_erule_query_ptr idx symbol fsym nptr cvars)
-           (fst (list_Mmap (compile_query_clause idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map qvs) assumptions S0)) ->
-        exists cargs cv out args,
-          qc_entry Qfin fsym nptr (cargs, cv)
-          /\ incl (out :: args) qvs
-          /\ cvars = filter (fun x => inb x (out :: args)) qvs
-          /\ cargs = map (named_list_lookup 0 (combine cvars (seq 0 (length cvars)))) args
-          /\ cv = named_list_lookup 0 (combine cvars (seq 0 (length cvars))) out
-          /\ (forall t, In t cargs -> t < length cvars)
-          /\ cv < length cvars.
+           (Hsub : forall a, In a assumptions -> forall x, In x (Defs.atom_ret a :: Defs.atom_args a) -> In x qvs),
+      vc (list_Mmap (compile_query_clause idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map qvs) assumptions)
+        (fun S0 res =>
+           wf_qc_state S0 ->
+           forall (Qfin : St),
+             (forall g j v, qc_entry (snd res) g j v -> qc_entry Qfin g j v) ->
+             forall fsym nptr cvars,
+               In (Build_erule_query_ptr idx symbol fsym nptr cvars) (fst res) ->
+               exists cargs cv out args,
+                 qc_entry Qfin fsym nptr (cargs, cv)
+                 /\ incl (out :: args) qvs
+                 /\ cvars = filter (fun x => inb x (out :: args)) qvs
+                 /\ cargs = map (named_list_lookup 0 (combine cvars (seq 0 (length cvars)))) args
+                 /\ cv = named_list_lookup 0 (combine cvars (seq 0 (length cvars))) out
+                 /\ (forall t, In t cargs -> t < length cvars)
+                 /\ cv < length cvars).
   Proof.
-    induction assumptions as [|a rest IH]; intros Hsub S0 Hwf0 Qfin Hmono fsym nptr cvars Hin.
+    intros qvs NDqvs assumptions.
+    induction assumptions as [|a rest IH]; unfold vc in *;
+      intros Hsub S0; cbn beta; intros Hwf0 Qfin Hmono fsym nptr cvars Hin.
     - cbn [list_Mmap Mbind Mret StateMonad.state_monad fst] in Hin. destruct Hin.
     - cbn [list_Mmap Mbind Mret StateMonad.state_monad] in Hin.
       destruct (compile_query_clause idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map qvs a S0) as [ptr S1] eqn:Hcqc.
@@ -4801,7 +4844,9 @@ Section WithMap.
         rewrite Hrec in Hentry; cbn [snd] in Hentry. exact Hentry. }
       assert (Hwf_S1_gen : wf_qc_state S1).
       { assert (HS1snd : S1 = snd (compile_query_clause idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map qvs a S0)) by (rewrite Hcqc; reflexivity).
-        rewrite HS1snd. apply (compile_query_clause_preserves_wf Hlts Hltt qvs a S0 Hwf0). }
+        rewrite HS1snd.
+        pose proof (compile_query_clause_preserves_wf Hlts Hltt qvs a) as Hcw0.
+        unfold vc in Hcw0. specialize (Hcw0 S0). exact (Hcw0 Hwf0). }
       destruct Hin as [Heq | Hrest].
       + destruct a as [f args out].
         unfold compile_query_clause in Hcqc.
@@ -4820,8 +4865,11 @@ Section WithMap.
         subst fsym. subst nptr. subst cvars.
         assert (Hwf_S1 : wf_qc_state S1).
         { assert (HS1snd : S1 = snd (hash_clause idx idx_succ idx_zero symbol symbol_map idx_map cc S0)) by (rewrite Hhc; reflexivity).
-          rewrite HS1snd. apply (hash_clause_preserves_wf Hlts Hltt cc S0 Hwf0). }
-        pose proof (hash_clause_sets cc S0) as Hsets.
+          rewrite HS1snd.
+          pose proof (hash_clause_preserves_wf Hlts Hltt cc) as Hcw1.
+          unfold vc in Hcw1. specialize (Hcw1 S0). exact (Hcw1 Hwf0). }
+        pose proof (hash_clause_sets cc) as Hsets.
+        unfold vc in Hsets. specialize (Hsets S0).
         assert (Hi_eq : i = fst (hash_clause idx idx_succ idx_zero symbol symbol_map idx_map cc S0)) by (rewrite Hhc; reflexivity).
         assert (HS1snd2 : S1 = snd (hash_clause idx idx_succ idx_zero symbol symbol_map idx_map cc S0)) by (rewrite Hhc; reflexivity).
         rewrite <- HS1snd2, <- Hi_eq in Hsets.
@@ -5775,16 +5823,17 @@ Section WithMap.
     (Hlts : forall x, lt x (idx_succ x))
     (Hltt : Transitive lt)
     (cs : list (Semantics.clause idx symbol))
-    (sub0 : named_list idx idx)
-    (e0 : Defs.instance idx symbol symbol_map idx_map idx_trie unit) :
-    match clauses_to_instance idx_succ (analysis_result:=unit) cs sub0 e0 with
-    | (_, sub1, e1) =>
-        idx_le ((equiv e0).(next _ _ _)) ((equiv e1).(next _ _ _))
-        /\ (forall x y, In (x, y) sub1 ->
-              In (x, y) sub0 \/ idx_le ((equiv e0).(next _ _ _)) y)
-    end.
+    (sub0 : named_list idx idx) :
+    vc (clauses_to_instance idx_succ (analysis_result:=unit) cs sub0)
+       (fun e0 res =>
+          match res with
+          | (_, sub1, e1) =>
+              idx_le ((equiv e0).(next _ _ _)) ((equiv e1).(next _ _ _))
+              /\ (forall x y, In (x, y) sub1 ->
+                    In (x, y) sub0 \/ idx_le ((equiv e0).(next _ _ _)) y)
+          end).
   Proof.
-    revert sub0 e0.
+    unfold vc. revert sub0.
     induction cs as [|c cs IH]; intros sub0 e0.
     - cbn. split.
       + apply idx_le_refl.
@@ -5822,18 +5871,20 @@ Section WithMap.
     (Hlti : Asymmetric lt) (Hlts : forall x, lt x (idx_succ x)) (Hltt : Transitive lt)
     (cs : list (Semantics.clause idx symbol))
     (sub0 : named_list idx idx)
-    (e0 : Defs.instance idx symbol symbol_map idx_map idx_trie unit)
     (x y : idx) :
-    (exists roots, UnionFind.union_find_ok lt (equiv e0) roots) ->
-    match clauses_to_instance idx_succ (analysis_result:=unit) cs sub0 e0 with
-    | (_, sub1, _) =>
-        In (x, y) sub1 ->
-        ~ In x (map fst sub0) ->
-        ~ Sep.has_key y (parent (equiv e0))
-    end.
+    vc (clauses_to_instance idx_succ (analysis_result:=unit) cs sub0)
+       (fun e0 res =>
+          (exists roots, UnionFind.union_find_ok lt (equiv e0) roots) ->
+          match res with
+          | (_, sub1, _) =>
+              In (x, y) sub1 ->
+              ~ In x (map fst sub0) ->
+              ~ Sep.has_key y (parent (equiv e0))
+          end).
   Proof.
-    intros [roots Hok].
-    pose proof (clauses_to_instance_next_invariant Hlts Hltt cs sub0 e0) as Hinv.
+    unfold vc; intro e0. cbn beta. intros [roots Hok].
+    pose proof (clauses_to_instance_next_invariant Hlts Hltt cs sub0) as Hinv.
+    unfold vc in Hinv. specialize (Hinv e0).
     destruct (clauses_to_instance idx_succ (analysis_result:=unit) cs sub0 e0)
       as [ [u sub1] e1] eqn:Hctc.
     cbn [fst snd] in Hinv |- *.
@@ -5993,15 +6044,16 @@ Section WithMap.
   Lemma clauses_to_instance_sub_in_domain
     (cs : list (Semantics.clause idx symbol))
     (sub0 : named_list idx idx)
-    (e0 : Defs.instance idx symbol symbol_map idx_map idx_trie unit)
     (x y : idx) :
-    match clauses_to_instance idx_succ (analysis_result:=unit) cs sub0 e0 with
-    | (_, sub1, _) =>
-        In (x, y) sub1 ->
-        In x (map fst sub0) \/ In x (flat_map (clause_vars idx symbol) cs)
-    end.
+    vc (clauses_to_instance idx_succ (analysis_result:=unit) cs sub0)
+       (fun e0 res =>
+          match res with
+          | (_, sub1, _) =>
+              In (x, y) sub1 ->
+              In x (map fst sub0) \/ In x (flat_map (clause_vars idx symbol) cs)
+          end).
   Proof.
-    revert sub0 e0.
+    unfold vc. revert sub0.
     induction cs as [|c cs IH]; intros sub0 e0.
     - cbn. intros Hxy. left. exact (in_map fst sub0 (x,y) Hxy).
     - cbn [Semantics.clauses_to_instance list_Miter].
@@ -6105,7 +6157,8 @@ Section WithMap.
     assert (Hsub_mono : forall z w, named_list_lookup_err sub1 z = Some w ->
        named_list_lookup_err sub2 z = Some w)
       by (intros z w Hzw;
-          pose proof (clauses_to_instance_sub_mono (seq_conclusions s) sub1 e_assum z w Hzw) as Hmm;
+          pose proof (clauses_to_instance_sub_mono (seq_conclusions s) sub1 z w) as Hmm;
+          unfold vc in Hmm; specialize (Hmm e_assum Hzw);
           rewrite Hcti_c in Hmm; exact Hmm).
     assert (Hvars_sub2 : forall a, In a atoms -> forall x, In x (atom_ret a :: atom_args a) ->
        exists y, named_list_lookup_err sub2 x = Some y)
@@ -6133,12 +6186,13 @@ Section WithMap.
     destruct (Semantics.empty_sound_for_interpretation idx lt idx_succ idx_zero symbol symbol_map
                 symbol_map_ok idx_map idx_map_ok idx_trie unit m) as [Hok_empty Hsnd_empty].
     pose proof (clauses_to_instance_preserves_ok Hlti Hlts Hltt m Hm (map atom_clause atoms) []
-       (empty_egraph idx_zero unit) (map.empty : idx_map (domain symbol m)) a_src
-       Hok_empty Hsnd_empty
-       ltac:(intros ? ? []) ltac:(intros ? ? []) Hsrc_assum) as Hpo_a.
+       (map.empty : idx_map (domain symbol m)) a_src) as Hpo_a.
+    unfold vc in Hpo_a. specialize (Hpo_a (empty_egraph idx_zero unit)).
     rewrite Hcti_a in Hpo_a.
+    specialize (Hpo_a Hok_empty Hsnd_empty
+       ltac:(intros ? ? []) ltac:(intros ? ? []) Hsrc_assum).
     destruct Hpo_a as [Hok_e1 [i_e1 [Hext_e1 [Hsnd_e1 [Hren_e1 Hdom_e1] ] ] ] ].
-    pose proof (@Semantics.rebuild_sound idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol Eqb_symbol Eqb_symbol_ok symbol_map symbol_map_ok idx_map idx_map_ok idx_trie idx_trie_ok unit _ m Hm (fun _ => True) RFUEL) as Hrs_a.
+    pose proof (@Semantics.rebuild_sound idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol Eqb_symbol Eqb_symbol_ok symbol_map symbol_map_ok idx_map idx_map_ok idx_trie idx_trie_ok unit _ m Hm RFUEL) as Hrs_a.
     unfold vc in Hrs_a. specialize (Hrs_a e1). rewrite Hrb_a in Hrs_a. cbn [snd] in Hrs_a.
     specialize (Hrs_a Hok_e1). destruct Hrs_a as [Hok_assum Hde_a].
     pose proof (proj1 (Hde_a i_e1) Hsnd_e1) as Hsnd_assum.
@@ -6193,8 +6247,8 @@ Section WithMap.
         apply in_map_iff in Hin_keys.
         destruct Hin_keys as ((x' & y') & Hxeq & Hin_pair).
         cbn [fst] in Hxeq. subst x'.
-        pose proof (clauses_to_instance_sub_in_domain (map atom_clause atoms) []
-                      (empty_egraph idx_zero unit) x y') as Hsd.
+        pose proof (clauses_to_instance_sub_in_domain (map atom_clause atoms) [] x y') as Hsd.
+        unfold vc in Hsd. specialize (Hsd (empty_egraph idx_zero unit)).
         rewrite Hcti_a in Hsd. specialize (Hsd Hin_pair).
         unfold forall_vars. rewrite Hassum.
         destruct Hsd as [Hnil | Hfv]; [ destruct Hnil | exact Hfv ].
@@ -6204,9 +6258,10 @@ Section WithMap.
           by (intro Hc;
               apply (@inb_is_In idx Eqb_idx Eqb_idx_ok) in Hc;
               rewrite Hib in Hc; exact Hc).
-        pose proof (clauses_to_instance_new_key_fresh Hlti Hlts Hltt (seq_conclusions s) sub1 e_assum x y
-                      (Semantics.egraph_equiv_ok _ _ _ _ _ _ _ _ Hok_assum)) as Hfresh.
+        pose proof (clauses_to_instance_new_key_fresh Hlti Hlts Hltt (seq_conclusions s) sub1 x y) as Hfresh.
+        unfold vc in Hfresh. specialize (Hfresh e_assum).
         rewrite Hcti_c in Hfresh.
+        specialize (Hfresh (Semantics.egraph_equiv_ok _ _ _ _ _ _ _ _ Hok_assum)).
         exact (Hfresh Hin_xy Hnin Hy_assum). }
     unfold model_satisfies_rule in Hsat.
     specialize (Hsat a_src Hkeys_src Hconf_src Hsrc_assum_s).
@@ -6214,8 +6269,8 @@ Section WithMap.
     (* a_src is defined on every key of sub1 (sub1 keys are source vars). *)
     assert (Ha_src_sub1_def : forall x y, In (x,y) sub1 -> exists d, map.get a_src x = Some d)
       by (intros x y Hxy;
-          pose proof (clauses_to_instance_sub_in_domain (map atom_clause atoms) []
-                        (empty_egraph idx_zero unit) x y) as Hdom;
+          pose proof (clauses_to_instance_sub_in_domain (map atom_clause atoms) [] x y) as Hdom;
+          unfold vc in Hdom; specialize (Hdom (empty_egraph idx_zero unit));
           rewrite Hcti_a in Hdom; specialize (Hdom Hxy);
           assert (Hin_fv : In x (forall_vars s))
             by (unfold forall_vars; rewrite Hassum;
@@ -6237,16 +6292,19 @@ Section WithMap.
       pose proof (Hren_e1 x y Hxy d0 Ha0) as Hi.
       apply (Semantics.interpretation_exact _ _ _ _ _ _ _ _ _ Hsnd_assum y).
       rewrite Hi; exact I. }
-    pose proof (clauses_to_instance_preserves_ok Hlti Hlts Hltt m Hm (seq_conclusions s) sub1 e_assum i_e1 a_src'
-       Hok_assum Hsnd_assum Hren_in Hsubdom_c Hconcl_src') as Hpo_c.
+    pose proof (clauses_to_instance_preserves_ok Hlti Hlts Hltt m Hm (seq_conclusions s) sub1 i_e1 a_src') as Hpo_c.
+    unfold vc in Hpo_c. specialize (Hpo_c e_assum).
     rewrite Hcti_c in Hpo_c.
+    specialize (Hpo_c Hok_assum Hsnd_assum Hren_in Hsubdom_c Hconcl_src').
     destruct Hpo_c as [Hok_c0 [i_c [Hext_c [Hsnd_c0 [Hren_c Hdom_c] ] ] ] ].
-    pose proof (@Semantics.rebuild_sound idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol Eqb_symbol Eqb_symbol_ok symbol_map symbol_map_ok idx_map idx_map_ok idx_trie idx_trie_ok unit _ m Hm (fun _ => True) RFUEL) as Hrs_c.
+    pose proof (@Semantics.rebuild_sound idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol Eqb_symbol Eqb_symbol_ok symbol_map symbol_map_ok idx_map idx_map_ok idx_trie idx_trie_ok unit _ m Hm RFUEL) as Hrs_c.
     unfold vc in Hrs_c. specialize (Hrs_c e_c0). rewrite Hrb_c in Hrs_c. cbn [snd] in Hrs_c.
     specialize (Hrs_c Hok_c0). destruct Hrs_c as [Hok_c1 Hde_c].
     pose proof (proj1 (Hde_c i_c) Hsnd_c0) as Hsnd_c1.
-    pose proof (force_equiv_preserves_sound m i_c e_c1 (Semantics.egraph_equiv_ok _ _ _ _ _ _ _ _ Hok_c1) Hsnd_c1) as Hsnd_fe.
+    pose proof (force_equiv_preserves_sound m i_c) as Hsnd_fe.
+    unfold vc in Hsnd_fe. specialize (Hsnd_fe e_c1).
     rewrite Hfe_c in Hsnd_fe. cbn [snd] in Hsnd_fe.
+    specialize (Hsnd_fe (Semantics.egraph_equiv_ok _ _ _ _ _ _ _ _ Hok_c1) Hsnd_c1).
     (* Steps 8-9: the final witness [map.putmany i_c a_opt] extends a_opt and
        agrees with i_c on i_c's domain (adversary match); read back the
        optimized conclusions soundly under i_c. *)
@@ -6286,11 +6344,12 @@ Section WithMap.
             (in_map (fun q => @eq_clause idx symbol (fst q) (snd q)) _ _ Hp)) as Hsp;
           cbn [uncurry fst snd] in Hsp |- *; exact Hsp
         | apply SemanticsUtil.all_map_in; intros a0 Ha0;
+          pose proof (@QueryOpt.incl_remove_atoms idx Eqb_idx Eqb_idx_ok lt symbol Eqb_symbol Eqb_symbol_ok
+                 symbol_map symbol_map_ok idx_map idx_trie idx_trie_ok unit AA) as Hira;
+          unfold vc in Hira; specialize (Hira e_c2); cbn [snd] in Hira;
           exact (in_all (clause_sound_for_model idx symbol idx_map m i_c) _ _
             (db_to_atoms_sound m i_c e_c2 Hsnd_fe)
-            (in_map (@atom_clause idx symbol) _ _
-              (@QueryOpt.incl_remove_atoms idx Eqb_idx Eqb_idx_ok lt symbol Eqb_symbol Eqb_symbol_ok
-                 symbol_map symbol_map_ok idx_map idx_trie idx_trie_ok unit AA e_c2 a0 Ha0))) ] ].
+            (in_map (@atom_clause idx symbol) _ _ (Hira a0 Ha0))) ] ].
   Qed.
 
   (* ================================================================ *)

--- a/src/Utils/EGraph/Semantics.v
+++ b/src/Utils/EGraph/Semantics.v
@@ -376,14 +376,6 @@ Section WithMap.
       forall default,
       map (fun x => named_list_lookup default (assign_sub a) x) (cv::cargs) <> (v::args).
   Proof.
-    (*
-    revert args acc a.induction cargs;
-      destruct args;
-      unfold passignment_forall,
-      assignment_correct;
-      basic_goal_prep;
-      basic_utils_crush.
-     *)
     Abort.
     
   (*TODO: too strong a statement.
@@ -404,20 +396,6 @@ Section WithMap.
     {
       revert H; case_match; try congruence.
       intros.
-
-      (*
-      Lemma insert_correct
-        : Some l = insert idx Eqb_idx acc a i ->
-          passignment_forall l1 l2 acc ->
-          passignment_forall l1 l2 acc ->
-          
-    
-  Lemma match_clause_correct default cargs cv args v assignment
-    : let sub := assign_sub assignment in
-      match_clause (cargs, cv) args v = Some assignment
-      -> map (fun x => named_list_lookup default sub x) (cv::cargs)
-         = v::args.
-  Proof.*)
       Abort.
   
   Lemma insert_nth_at n val acc acc'
@@ -771,23 +749,29 @@ Section WithMap.
   Qed.
 
   Lemma build_tries_sound (window : nat) (q : rule_set idx symbol symbol_map idx_map)
-    (inst : instance)
     (f : symbol) (n : idx) (clause : list nat * nat)
     (clause_tries : idx_map (idx_trie unit * idx_trie unit * idx_trie unit))
     (trie_pair : idx_trie unit * idx_trie unit * idx_trie unit) (assignment : list idx)
     (q_f : idx_map (list nat * nat)) :
-    map.get (q.(query_clauses idx symbol symbol_map idx_map)) f = Some q_f ->
-    map.get q_f n = Some clause ->
-    map.get (fst (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
-      idx_map idx_map_plus idx_trie analysis_result window q inst)) f = Some clause_tries ->
-    map.get clause_tries n = Some trie_pair ->
-    map.get (fst (fst trie_pair)) assignment = Some tt ->
-    exists args v,
-      atom_in_db (Build_atom f args v) inst.(db)
-      /\ match_clause clause args v = Some assignment.
+    vc (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
+          idx_map idx_map_plus idx_trie analysis_result window q)
+      (fun inst res =>
+         map.get (q.(query_clauses idx symbol symbol_map idx_map)) f = Some q_f ->
+         map.get q_f n = Some clause ->
+         map.get (fst res) f = Some clause_tries ->
+         map.get clause_tries n = Some trie_pair ->
+         map.get (fst (fst trie_pair)) assignment = Some tt ->
+         exists args v,
+           atom_in_db (Build_atom f args v) inst.(db)
+           /\ match_clause clause args v = Some assignment).
   Proof.
+    unfold vc. intro inst.
+    destruct (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
+      idx_map idx_map_plus idx_trie analysis_result window q inst) as [bt_v bt_s] eqn:Hbt.
+    cbn [fst snd].
     intros Hqf Hclause Hbt_f Hct_n Hfull.
-    unfold build_tries in Hbt_f. cbn [fst] in Hbt_f.
+    unfold build_tries in Hbt. injection Hbt as Hbt_v Hbt_s. subst bt_v.
+    cbn [fst] in Hbt_f.
     rewrite (@intersect_spec _ symbol_map _ symbol_map_plus_ok) in Hbt_f.
     rewrite Hqf in Hbt_f.
     destruct (map.get inst.(db) f) as [ tbl | ] eqn:Htbl.
@@ -893,18 +877,24 @@ Section WithMap.
   Qed.
 
   Lemma build_tries_frontier_subset (window : nat) (q : rule_set idx symbol symbol_map idx_map)
-    (inst : instance)
     (f : symbol) (n : idx)
     (clause_tries : idx_map (idx_trie unit * idx_trie unit * idx_trie unit))
     (trie_pair : idx_trie unit * idx_trie unit * idx_trie unit) (assignment : list idx) :
-    map.get (fst (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
-      idx_map idx_map_plus idx_trie analysis_result window q inst)) f = Some clause_tries ->
-    map.get clause_tries n = Some trie_pair ->
-    map.get (snd (fst trie_pair)) assignment = Some tt ->
-    map.get (fst (fst trie_pair)) assignment = Some tt.
+    vc (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
+          idx_map idx_map_plus idx_trie analysis_result window q)
+      (fun inst res =>
+         map.get (fst res) f = Some clause_tries ->
+         map.get clause_tries n = Some trie_pair ->
+         map.get (snd (fst trie_pair)) assignment = Some tt ->
+         map.get (fst (fst trie_pair)) assignment = Some tt).
   Proof.
+    unfold vc. intro inst.
+    destruct (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
+      idx_map idx_map_plus idx_trie analysis_result window q inst) as [bt_v bt_s] eqn:Hbt.
+    cbn [fst snd].
     intros Hbt_f Hct_n Hfront.
-    unfold build_tries in Hbt_f. cbn [fst] in Hbt_f.
+    unfold build_tries in Hbt. injection Hbt as Hbt_v Hbt_s. subst bt_v.
+    cbn [fst] in Hbt_f.
     rewrite (@intersect_spec _ symbol_map _ symbol_map_plus_ok) in Hbt_f.
     destruct (map.get (query_clauses idx symbol symbol_map idx_map q) f) as [ q_f | ] eqn:Hqf.
     - destruct (map.get inst.(db) f) as [ tbl | ] eqn:Htbl.
@@ -920,33 +910,38 @@ Section WithMap.
   Qed.
 
   Lemma clause_ptr_atom_in_db
-    (window : nat) (q : rule_set idx symbol symbol_map idx_map) (inst : instance)
+    (window : nat) (q : rule_set idx symbol symbol_map idx_map)
     (query_vars : list idx) (frontier_n : idx)
     (f : symbol) (n : idx) (clause_vars : list idx)
     (q_f : idx_map (list nat * nat)) (clause : list nat * nat)
     (sigma : list idx) :
-    map.get (query_clauses idx symbol symbol_map idx_map q) f = Some q_f ->
-    map.get q_f n = Some clause ->
-    map.get (fst (trie_of_clause idx Eqb_idx symbol symbol_map idx_map idx_trie
-                    query_vars
-                    (fst (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
-                            idx_map idx_map_plus idx_trie analysis_result window q inst))
-                    frontier_n (Build_erule_query_ptr idx symbol f n clause_vars)))
-            (map fst (filter snd (combine sigma
-               (variable_flags idx Eqb_idx query_vars clause_vars))))
-          = Some tt ->
-    exists args v,
-      atom_in_db (Build_atom f args v) inst.(db)
-      /\ match_clause clause args v
-         = Some (map fst (filter snd (combine sigma
-                   (variable_flags idx Eqb_idx query_vars clause_vars)))).
+    vc (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
+          idx_map idx_map_plus idx_trie analysis_result window q)
+      (fun inst res =>
+         map.get (query_clauses idx symbol symbol_map idx_map q) f = Some q_f ->
+         map.get q_f n = Some clause ->
+         map.get (fst (trie_of_clause idx Eqb_idx symbol symbol_map idx_map idx_trie
+                         query_vars
+                         (fst res)
+                         frontier_n (Build_erule_query_ptr idx symbol f n clause_vars)))
+                 (map fst (filter snd (combine sigma
+                    (variable_flags idx Eqb_idx query_vars clause_vars))))
+               = Some tt ->
+         exists args v,
+           atom_in_db (Build_atom f args v) inst.(db)
+           /\ match_clause clause args v
+              = Some (map fst (filter snd (combine sigma
+                        (variable_flags idx Eqb_idx query_vars clause_vars))))).
   Proof.
+    unfold vc. intro inst.
+    destruct (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
+      idx_map idx_map_plus idx_trie analysis_result window q inst) as [bt_v bt_s] eqn:Hbt.
+    cbn [fst snd].
     intros Hqf Hclause Hhit.
     unfold trie_of_clause in Hhit.
     cbn [fst snd] in Hhit.
     set (proj := map fst (filter snd (combine sigma (variable_flags idx Eqb_idx query_vars clause_vars)))).
-    set (db_tries := fst (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
-                            idx_map idx_map_plus idx_trie analysis_result window q inst)).
+    set (db_tries := bt_v).
     destruct (map.get db_tries f) as [ trie_list | ] eqn:Hf.
     - (* Some trie_list case *)
       fold db_tries in Hhit.
@@ -959,17 +954,22 @@ Section WithMap.
         * (* eqb n frontier_n = true, new_ case *)
           fold proj in Hhit.
           assert (Hfull : map.get (fst (fst (total, new_, old_))) proj = Some tt). {
-            apply (build_tries_frontier_subset window q inst f n trie_list (total, new_, old_) proj Hf Hn).
-            exact Hhit.
+            pose proof (build_tries_frontier_subset window q f n trie_list (total, new_, old_) proj) as Hfs.
+            unfold vc in Hfs. specialize (Hfs inst). rewrite Hbt in Hfs. cbn [fst snd] in Hfs.
+            apply Hfs; [ exact Hf | exact Hn | exact Hhit ].
           }
           cbn [fst] in Hfull.
-          pose proof (build_tries_sound window q inst f n clause trie_list (total, new_, old_) proj q_f Hqf Hclause Hf Hn Hfull)
+          pose proof (build_tries_sound window q f n clause trie_list (total, new_, old_) proj q_f) as Hsnd.
+          unfold vc in Hsnd. specialize (Hsnd inst). rewrite Hbt in Hsnd. cbn [fst snd] in Hsnd.
+          destruct (Hsnd Hqf Hclause Hf Hn Hfull)
             as [ args [ v [Hdb Hmatch] ] ].
           exists args. exists v.
           exact (conj Hdb Hmatch).
         * (* eqb n frontier_n = false, total case *)
           fold proj in Hhit.
-          pose proof (build_tries_sound window q inst f n clause trie_list (total, new_, old_) proj q_f Hqf Hclause Hf Hn Hhit)
+          pose proof (build_tries_sound window q f n clause trie_list (total, new_, old_) proj q_f) as Hsnd.
+          unfold vc in Hsnd. specialize (Hsnd inst). rewrite Hbt in Hsnd. cbn [fst snd] in Hsnd.
+          destruct (Hsnd Hqf Hclause Hf Hn Hhit)
             as [ args [ v [Hdb Hmatch] ] ].
           exists args. exists v.
           exact (conj Hdb Hmatch).
@@ -1072,18 +1072,24 @@ Section WithMap.
   Qed.
 
   Lemma build_tries_old_subset (window : nat) (q : rule_set idx symbol symbol_map idx_map)
-    (inst : instance)
     (f : symbol) (n : idx)
     (clause_tries : idx_map (idx_trie unit * idx_trie unit * idx_trie unit))
     (trie_pair : idx_trie unit * idx_trie unit * idx_trie unit) (assignment : list idx) :
-    map.get (fst (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
-      idx_map idx_map_plus idx_trie analysis_result window q inst)) f = Some clause_tries ->
-    map.get clause_tries n = Some trie_pair ->
-    map.get (snd trie_pair) assignment = Some tt ->
-    map.get (fst (fst trie_pair)) assignment = Some tt.
+    vc (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
+          idx_map idx_map_plus idx_trie analysis_result window q)
+      (fun inst res =>
+         map.get (fst res) f = Some clause_tries ->
+         map.get clause_tries n = Some trie_pair ->
+         map.get (snd trie_pair) assignment = Some tt ->
+         map.get (fst (fst trie_pair)) assignment = Some tt).
   Proof.
+    unfold vc. intro inst.
+    destruct (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
+      idx_map idx_map_plus idx_trie analysis_result window q inst) as [bt_v bt_s] eqn:Hbt.
+    cbn [fst snd].
     intros Hbt_f Hct_n Hfront.
-    unfold build_tries in Hbt_f. cbn [fst] in Hbt_f.
+    unfold build_tries in Hbt. injection Hbt as Hbt_v Hbt_s. subst bt_v.
+    cbn [fst] in Hbt_f.
     rewrite (@intersect_spec _ symbol_map _ symbol_map_plus_ok) in Hbt_f.
     destruct (map.get (query_clauses idx symbol symbol_map idx_map q) f) as [ q_f | ] eqn:Hqf.
     - destruct (map.get inst.(db) f) as [ tbl | ] eqn:Htbl.
@@ -1103,33 +1109,38 @@ Section WithMap.
      (old if pos<frontier_pos, new if =, full if >) reduces to a db atom via the
      subset lemmas + build_tries_sound. *)
   Lemma clause_ptr_atom_in_db_sn
-    (window : nat) (q : rule_set idx symbol symbol_map idx_map) (inst : instance)
+    (window : nat) (q : rule_set idx symbol symbol_map idx_map)
     (query_vars : list idx) (frontier_pos pos : nat)
     (f : symbol) (n : idx) (clause_vars : list idx)
     (q_f : idx_map (list nat * nat)) (clause : list nat * nat)
     (sigma : list idx) :
-    map.get (query_clauses idx symbol symbol_map idx_map q) f = Some q_f ->
-    map.get q_f n = Some clause ->
-    map.get (fst (trie_of_clause_sn idx Eqb_idx symbol symbol_map idx_map idx_trie
-                    query_vars
-                    (fst (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
-                            idx_map idx_map_plus idx_trie analysis_result window q inst))
-                    frontier_pos pos (Build_erule_query_ptr idx symbol f n clause_vars)))
-            (map fst (filter snd (combine sigma
-               (variable_flags idx Eqb_idx query_vars clause_vars))))
-          = Some tt ->
-    exists args v,
-      atom_in_db (Build_atom f args v) inst.(db)
-      /\ match_clause clause args v
-         = Some (map fst (filter snd (combine sigma
-                   (variable_flags idx Eqb_idx query_vars clause_vars)))).
+    vc (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
+          idx_map idx_map_plus idx_trie analysis_result window q)
+      (fun inst res =>
+         map.get (query_clauses idx symbol symbol_map idx_map q) f = Some q_f ->
+         map.get q_f n = Some clause ->
+         map.get (fst (trie_of_clause_sn idx Eqb_idx symbol symbol_map idx_map idx_trie
+                         query_vars
+                         (fst res)
+                         frontier_pos pos (Build_erule_query_ptr idx symbol f n clause_vars)))
+                 (map fst (filter snd (combine sigma
+                    (variable_flags idx Eqb_idx query_vars clause_vars))))
+               = Some tt ->
+         exists args v,
+           atom_in_db (Build_atom f args v) inst.(db)
+           /\ match_clause clause args v
+              = Some (map fst (filter snd (combine sigma
+                        (variable_flags idx Eqb_idx query_vars clause_vars))))).
   Proof.
+    unfold vc. intro inst.
+    destruct (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
+      idx_map idx_map_plus idx_trie analysis_result window q inst) as [bt_v bt_s] eqn:Hbt.
+    cbn [fst snd].
     intros Hqf Hclause Hhit.
     unfold trie_of_clause_sn in Hhit.
     cbn [fst snd] in Hhit.
     set (proj := map fst (filter snd (combine sigma (variable_flags idx Eqb_idx query_vars clause_vars)))).
-    set (db_tries := fst (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
-                            idx_map idx_map_plus idx_trie analysis_result window q inst)).
+    set (db_tries := bt_v).
     destruct (map.get db_tries f) as [ trie_list | ] eqn:Hf.
     - (* Some trie_list case *)
       fold db_tries in Hhit.
@@ -1145,11 +1156,14 @@ Section WithMap.
             cbn [fst snd]. exact Hhit.
           }
           assert (Hfull : map.get (fst (fst (full, new_, old_))) proj = Some tt). {
-            apply (build_tries_frontier_subset window q inst f n trie_list (full, new_, old_) proj Hf Hn).
-            exact Hhit'.
+            pose proof (build_tries_frontier_subset window q f n trie_list (full, new_, old_) proj) as Hfs.
+            unfold vc in Hfs. specialize (Hfs inst). rewrite Hbt in Hfs. cbn [fst snd] in Hfs.
+            apply Hfs; [ exact Hf | exact Hn | exact Hhit' ].
           }
           cbn [fst] in Hfull.
-          pose proof (build_tries_sound window q inst f n clause trie_list (full, new_, old_) proj q_f Hqf Hclause Hf Hn Hfull)
+          pose proof (build_tries_sound window q f n clause trie_list (full, new_, old_) proj q_f) as Hsnd.
+          unfold vc in Hsnd. specialize (Hsnd inst). rewrite Hbt in Hsnd. cbn [fst snd] in Hsnd.
+          destruct (Hsnd Hqf Hclause Hf Hn Hfull)
             as [ args [ v [Hdb Hmatch] ] ].
           exists args. exists v.
           exact (conj Hdb Hmatch).
@@ -1159,11 +1173,14 @@ Section WithMap.
             cbn [fst snd]. exact Hhit.
           }
           assert (Hfull : map.get (fst (fst (full, new_, old_))) proj = Some tt). {
-            apply (build_tries_old_subset window q inst f n trie_list (full, new_, old_) proj Hf Hn).
-            exact Hhit_old.
+            pose proof (build_tries_old_subset window q f n trie_list (full, new_, old_) proj) as Hos.
+            unfold vc in Hos. specialize (Hos inst). rewrite Hbt in Hos. cbn [fst snd] in Hos.
+            apply Hos; [ exact Hf | exact Hn | exact Hhit_old ].
           }
           cbn [fst] in Hfull.
-          pose proof (build_tries_sound window q inst f n clause trie_list (full, new_, old_) proj q_f Hqf Hclause Hf Hn Hfull)
+          pose proof (build_tries_sound window q f n clause trie_list (full, new_, old_) proj q_f) as Hsnd.
+          unfold vc in Hsnd. specialize (Hsnd inst). rewrite Hbt in Hsnd. cbn [fst snd] in Hsnd.
+          destruct (Hsnd Hqf Hclause Hf Hn Hfull)
             as [ args [ v [Hdb Hmatch] ] ].
           exists args. exists v.
           exact (conj Hdb Hmatch).
@@ -1172,7 +1189,9 @@ Section WithMap.
           assert (Hhit_full : map.get (fst (fst (full, new_, old_))) proj = Some tt). {
             cbn [fst snd]. exact Hhit.
           }
-          pose proof (build_tries_sound window q inst f n clause trie_list (full, new_, old_) proj q_f Hqf Hclause Hf Hn Hhit_full)
+          pose proof (build_tries_sound window q f n clause trie_list (full, new_, old_) proj q_f) as Hsnd.
+          unfold vc in Hsnd. specialize (Hsnd inst). rewrite Hbt in Hsnd. cbn [fst snd] in Hsnd.
+          destruct (Hsnd Hqf Hclause Hf Hn Hhit_full)
             as [ args [ v [Hdb Hmatch] ] ].
           exists args. exists v.
           exact (conj Hdb Hmatch).
@@ -1301,16 +1320,6 @@ Section WithMap.
         /\ all (atom_sound_for_model m a_src) (write_clauses idx symbol r)
         /\ all (fun p => eq_sound_for_model m a_src (fst p) (snd p))
                (write_unifications idx symbol r).
-
-  (*
-  (*Defined separately for proof convenience.
-    Equivalent to a term using ~ atom_in_egraph
-   *)
-  Definition not_key_in_egraph a (i : instance) :=
-    (map.get i.(db _ _ _ _ _) a.(atom_fn)) <?>
-      (fun tbl => (map.get tbl a.(atom_args)) <?>
-                    (fun r => False)).
-  *)
 
   Definition SomeRel {A B} (R : A -> B -> Prop) ma mb :=
     ma <$> (fun x => mb <$> (R x)).
@@ -1468,11 +1477,7 @@ Section WithMap.
     destruct (empty_sound_for_interpretation m) as [Hok Hsound].
     split; [exact Hok | exists map.empty; exact Hsound].
   Qed.
-  
-  (*
-  Notation rebuild := (rebuild idx Eqb_idx symbol Eqb_symbol symbol_map idx_map idx_trie).
-  *)
-    
+
   (*TODO: move *)
   Lemma get_update_diff K V (mp : map.map K V) {H : map.ok mp} `{WithDefault V} (m : mp) k k' f
     : k <> k' -> map.get (map_update m k f) k'
@@ -6368,10 +6373,13 @@ Section WithMap.
   Qed.
 
   (* Helper: [find] on a root element is the identity on the full instance. *)
-  Lemma find_root_identity (inst : instance) (x : idx)
-    : map.get inst.(equiv).(parent) x = Some x ->
-      find x inst = (x, inst).
+  Lemma find_root_identity (x : idx)
+    : vc (find x)
+        (fun inst res =>
+           map.get inst.(equiv).(parent) x = Some x ->
+           res = (x, inst)).
   Proof.
+    unfold vc; intro inst.
     intro Hroot.
     unfold find, Defs.find.
     cbn.
@@ -6385,11 +6393,14 @@ Section WithMap.
   Qed.
 
   (* Helper: path-compressing [find] preserves root-status of any node z. *)
-  Lemma find_roots_mono (x z : idx) (e : instance)
-    : (exists roots, union_find_ok lt e.(equiv) roots) ->
-      map.get e.(equiv).(parent) z = Some z ->
-      map.get (snd (Defs.find x e)).(equiv).(parent) z = Some z.
+  Lemma find_roots_mono (x z : idx)
+    : vc (find x)
+        (fun e res =>
+           (exists roots, union_find_ok lt e.(equiv) roots) ->
+           map.get e.(equiv).(parent) z = Some z ->
+           map.get (snd res).(equiv).(parent) z = Some z).
   Proof.
+    unfold vc; intro e.
     intros [roots Hok] Hz.
     unfold Defs.find.
     destruct (UnionFind.find e.(equiv) x) as [uf' v'] eqn:Hfind.
@@ -6416,11 +6427,14 @@ Section WithMap.
   (* Helper: path-compressing [find] preserves the existence of a uf_ok witness. *)
   (* Helper: list_Mmap of find preserves root-status of any node z. *)
   (* Helper: [find] returns a value that is a root in the result union-find. *)
-  Lemma find_returns_root (x : idx) (e : instance)
-    : (exists roots, union_find_ok lt e.(equiv) roots) ->
-      Sep.has_key x e.(equiv).(parent) ->
-      map.get (snd (Defs.find x e)).(equiv).(parent) (fst (Defs.find x e)) = Some (fst (Defs.find x e)).
+  Lemma find_returns_root (x : idx)
+    : vc (find x)
+        (fun e res =>
+           (exists roots, union_find_ok lt e.(equiv) roots) ->
+           Sep.has_key x e.(equiv).(parent) ->
+           map.get (snd res).(equiv).(parent) (fst res) = Some (fst res)).
   Proof.
+    unfold vc; intro e.
     intros [roots Hok] Hkey.
     unfold Defs.find.
     destruct (UnionFind.find e.(equiv) x) as [uf' v'] eqn:Hfind.
@@ -6437,17 +6451,21 @@ Section WithMap.
   (* Internal helper: two consecutive finds of the same node x give the same rep cv2 = cv. *)
   (* Helper: [union v v] preserves root-status of any node z. *)
   (* Helper: [list_Mmap find] on a list of root elements is the identity. *)
-  Lemma list_Mmap_find_roots_identity (xs : list idx) (inst : instance)
-    : all (fun x => map.get inst.(equiv).(parent) x = Some x) xs ->
-      list_Mmap find xs inst = (xs, inst).
+  Lemma list_Mmap_find_roots_identity (xs : list idx)
+    : vc (list_Mmap find xs)
+        (fun inst res =>
+           all (fun x => map.get inst.(equiv).(parent) x = Some x) xs ->
+           res = (xs, inst)).
   Proof.
-    induction xs as [| x xs' IH]; intro Hall.
+    unfold vc.
+    induction xs as [| x xs' IH]; intros inst Hall.
     - (* base *) reflexivity.
     - (* step *) cbn [all] in Hall. destruct Hall as [Hx Hxs'].
       cbn [list_Mmap Mbind StateMonad.state_monad fst snd].
-      rewrite (find_root_identity inst x Hx).
+      pose proof (find_root_identity x) as Hfri. unfold vc in Hfri.
+      rewrite (Hfri inst Hx).
       cbn [fst snd].
-      rewrite (IH Hxs').
+      rewrite (IH inst Hxs').
       reflexivity.
   Qed.
 
@@ -6587,8 +6605,10 @@ Section WithMap.
   Proof.
     unfold vc, Defs.union.
     intros e_in roots Hok Hrv Hrv1 Hneq Hr0.
-    pose proof (find_root_identity e_in v Hrv) as Hdfv.
-    pose proof (find_root_identity e_in v1 Hrv1) as Hdfv1.
+    pose proof (find_root_identity v) as Hdfv0. unfold vc in Hdfv0.
+    pose proof (Hdfv0 e_in Hrv) as Hdfv.
+    pose proof (find_root_identity v1) as Hdfv10. unfold vc in Hdfv10.
+    pose proof (Hdfv10 e_in Hrv1) as Hdfv1.
     cbn [Mbind StateMonad.state_monad].
     rewrite Hdfv. cbn [fst snd].
     rewrite Hdfv1. cbn [fst snd].
@@ -8887,32 +8907,9 @@ Section WithMap.
         eapply PER_clo_trans.
         - apply PER_clo_sym. exact Hper_ret_dbr2.
         - exact Hper_ret_dbr. }
-      (* a_ret' is a root in e_dbr: find_returns_root gives root in e_canon,
-         but e_dbr and e_canon have the same PER so roots are the same there.
-         Actually we need map.get e_dbr.equiv.parent a_ret' = Some a_ret'.
-         Use: find_returns_root gives root in e_canon; HPER_canon gives PER-iff.
-         Two things: (1) a_ret' is root in e_canon (Hroot_ret'), (2) x_canonical
-         is root in e_dbr (Hroot_xc_dbr), apply roots_uf_rel_eq with e_dbr. *)
-      (* BUT: Hroot_ret' is in e_canon, not e_dbr. We need it in e_dbr.
-         find_root_identity: if root in e_dbr, find a_ret' e_dbr = (a_ret', e_dbr).
-         Alternatively: use roots_uf_rel_eq on e_dbr with Huf_dbr.
-         We need: map.get e_dbr.equiv.parent a_ret' = Some a_ret'.
-         Hroot_ret' : map.get e_canon.equiv.parent a_ret' = Some a_ret'
-         (a_ret' is root in e_canon).
-         The key-iff from HPER_canon doesn't directly give root-iff.
-         Use the iff2 from find_sound' differently. *)
-      (* Alternative: use find_root_identity on e_dbr.
-         a_ret' is the result of find a_ret e_dbr, and find gives the root.
-         So find_returns_root applied to e_dbr gives root in e_dbr directly. *)
-      (* Actually find_returns_root for e_dbr is what we want: it gives
-         map.get (snd (find a_ret e_dbr)).equiv.parent (fst (find a_ret e_dbr)) = Some (fst...)
-         = map.get e_canon.equiv.parent a_ret' = Some a_ret' = Hroot_ret'.
-         But this is in e_canon, not e_dbr. *)
-      (* Use: find_sound' gives Huf_c : union_find_ok lt e_canon.equiv roots_init.
-         Since a_ret' is a root in e_canon (Hroot_ret') and x_canonical is root in
-         e_dbr, and uf_rel_PER e_dbr iff2 uf_rel_PER e_canon:
-         Hper_combined_canon : uf_rel_PER e_canon.equiv a_ret' x_canonical via HPER_canon.
-         x_canonical root in e_canon: find_roots_mono for x_canonical through find a_ret e_dbr. *)
+      (* a_ret' is a root in e_canon (Hroot_ret') and x_canonical is a root in
+         e_dbr; transport x_canonical's rootness to e_canon via find_roots_mono
+         and combine with the PER fact through e_canon. *)
       assert (Hroot_xc_canon : map.get e_canon.(equiv).(parent) x_canonical = Some x_canonical).
       { assert (He_canon_eq : e_canon = snd (find a_ret e_dbr)) by (rewrite Hfind_ret; reflexivity).
         rewrite He_canon_eq.
@@ -10526,18 +10523,19 @@ Section WithMap.
      entries, so the canonicalization pass of rebuild is a no-op on a
      worklist holding only analysis_repair entries. *)
   Lemma list_Mmap_canon_ar l
-    : all (fun ent => exists j, ent = analysis_repair idx j) l ->
-      forall e, list_Mmap (canonicalize_worklist_entry idx Eqb_idx symbol symbol_map idx_map idx_trie analysis_result) l e = (l, e).
+    : vc (list_Mmap (canonicalize_worklist_entry idx Eqb_idx symbol symbol_map idx_map idx_trie analysis_result) l)
+        (fun e res =>
+           all (fun ent => exists j, ent = analysis_repair idx j) l ->
+           res = (l, e)).
   Proof.
-    induction l as [|a l IH]; intros Hall e.
+    induction l as [|a l IH]; unfold vc; intros e Hall.
     - reflexivity.
     - cbn [all] in Hall. destruct Hall as [ [j Hj] Hall_rest ]. subst a.
       cbn [list_Mmap canonicalize_worklist_entry].
       unfold Mbind, Mret, StateMonad.state_monad.
+      specialize (IH e Hall_rest).
       destruct (list_Mmap (canonicalize_worklist_entry idx Eqb_idx symbol symbol_map idx_map idx_trie analysis_result) l e) as [xs e'] eqn:Hlm.
-      pose proof (IH Hall_rest e) as HIH.
-      pose proof (eq_trans (eq_sym Hlm) HIH) as Heq.
-      inversion Heq; subst. reflexivity.
+      inversion IH; subst. reflexivity.
   Qed.
 
   (* MAIN: when the worklist holds only analysis_repair entries (the
@@ -10562,7 +10560,8 @@ Section WithMap.
       + cbn [Mret StateMonad.state_monad snd db worklist].
         split; [intros a; reflexivity | exact I].
       + match goal with |- context[list_Mmap ?f (w::wl') ?st] =>
-          pose proof (list_Mmap_canon_ar (w::wl') Hwl st) as Hcanon end.
+          pose proof (list_Mmap_canon_ar (w::wl')) as Hcanon;
+          unfold vc in Hcanon; specialize (Hcanon st Hwl) end.
         rewrite Hcanon. cbn [Mseq Mbind StateMonad.state_monad].
         assert (Hdedup : all (fun ent => exists j, ent = analysis_repair idx j) (w::wl'))
           by exact Hwl.
@@ -10627,7 +10626,8 @@ Section WithMap.
       + cbn [Mret StateMonad.state_monad snd db worklist].
         reflexivity.
       + match goal with |- context[list_Mmap ?f (w::wl') ?st] =>
-            pose proof (list_Mmap_canon_ar (w::wl') Hwl st) as Hcanon end.
+            pose proof (list_Mmap_canon_ar (w::wl')) as Hcanon;
+            unfold vc in Hcanon; specialize (Hcanon st Hwl) end.
         rewrite Hcanon. cbn [Mseq Mbind StateMonad.state_monad].
         assert (Hdedup : all (fun ent => exists j, ent = analysis_repair idx j) (w::wl'))
           by exact Hwl.
@@ -10652,7 +10652,7 @@ Section WithMap.
      worklist, is still literally present (atom_in_egraph) after rebuild.
      Forward/survival direction only; follows immediately from
      rebuild_preserves_atom_in_db (which gives the biconditional on atom_in_db). *)
-  Lemma rebuild_sound (Pre : idx_map (domain m) -> Prop) n
+  Lemma rebuild_sound n
     : vc (rebuild n)
         (fun e res =>
            egraph_ok e ->

--- a/src/Utils/EGraph/SemanticsAnalysesCover.v
+++ b/src/Utils/EGraph/SemanticsAnalysesCover.v
@@ -34,7 +34,6 @@ Lemma alloc_opaque_analyses_cover
   {idx_map : forall A, map.map idx A} {idx_map_ok : forall A, map.ok (idx_map A)}
   {idx_trie : forall A, map.map (list idx) A} {analysis_result : Type}
   {HA : analysis idx symbol analysis_result}
-  (Hlti : Asymmetric lt) (Hlts : forall x, lt x (idx_succ x)) (Hltt : Transitive lt)
   : vc (alloc_opaque idx idx_succ symbol symbol_map idx_map idx_trie analysis_result)
       (fun e res =>
          egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result e ->

--- a/src/Utils/EGraph/SemanticsAreUnified.v
+++ b/src/Utils/EGraph/SemanticsAreUnified.v
@@ -17,14 +17,17 @@ Import Monad.StateMonad.
     (symbol : Type) (symbol_map : forall A, map.map symbol A)
     (idx_map : forall A, map.map idx A) (idx_map_ok : forall A, map.ok (idx_map A))
     (idx_trie : forall A, map.map (list idx) A) (analysis_result : Type)
-    (x1 x2 : idx) (e : instance idx symbol symbol_map idx_map idx_trie analysis_result) :
-    (exists l, union_find_ok lt e.(equiv) l) ->
-    Sep.has_key x1 e.(equiv).(parent) ->
-    Sep.has_key x2 e.(equiv).(parent) ->
-    fst (@are_unified _ Eqb_idx _ _ _ _ _ x1 x2 e) = true ->
-    uf_rel_PER idx (idx_map idx) (idx_map nat) e.(equiv) x1 x2.
+    (x1 x2 : idx) :
+    vc (@are_unified idx Eqb_idx symbol symbol_map idx_map idx_trie analysis_result x1 x2)
+      (fun e res =>
+         (exists l, union_find_ok lt e.(equiv) l) ->
+         Sep.has_key x1 e.(equiv).(parent) ->
+         Sep.has_key x2 e.(equiv).(parent) ->
+         fst res = true ->
+         uf_rel_PER idx (idx_map idx) (idx_map nat) e.(equiv) x1 x2).
   Proof.
-    intros Hok Hk1 Hk2 Hunified.
+    unfold vc; intros e Hok Hk1 Hk2 Hunified.
+    cbn [fst] in Hunified.
     unfold are_unified in Hunified.
     cbn [Mbind Mret StateMonad.state_monad] in Hunified.
     pose proof (@find_preserves_fields_strong idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol symbol_map idx_map idx_map_ok idx_trie analysis_result x1 e Hok Hk1) as Hf1.
@@ -52,18 +55,22 @@ Import Monad.StateMonad.
     (idx_map : forall A, map.map idx A) (idx_map_ok : forall A, map.ok (idx_map A))
     (idx_trie : forall A, map.map (list idx) A) (analysis_result : Type)
     (m : model symbol)
-    (x1 x2 : idx) (e : instance idx symbol symbol_map idx_map idx_trie analysis_result)
+    (x1 x2 : idx)
     (i : idx_map (domain symbol m)) :
-    egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result e ->
-    egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i e ->
-    Sep.has_key x1 e.(equiv).(parent) ->
-    Sep.has_key x2 e.(equiv).(parent) ->
-    fst (@are_unified _ Eqb_idx _ _ _ _ _ x1 x2 e) = true ->
-    eq_sound_for_model idx symbol idx_map m i x1 x2.
+    vc (@are_unified idx Eqb_idx symbol symbol_map idx_map idx_trie analysis_result x1 x2)
+      (fun e res =>
+         egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result e ->
+         egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i e ->
+         Sep.has_key x1 e.(equiv).(parent) ->
+         Sep.has_key x2 e.(equiv).(parent) ->
+         fst res = true ->
+         eq_sound_for_model idx symbol idx_map m i x1 x2).
   Proof.
-    intros Hok Hsnd Hk1 Hk2 Hu.
+    unfold vc; intros e Hok Hsnd Hk1 Hk2 Hu.
     apply (rel_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i e Hsnd).
-    apply (@are_unified_sound idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol symbol_map idx_map idx_map_ok idx_trie analysis_result x1 x2 e); try assumption.
+    pose proof (@are_unified_sound idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol symbol_map idx_map idx_map_ok idx_trie analysis_result x1 x2) as Has.
+    unfold vc in Has. specialize (Has e).
+    apply Has; try assumption.
     apply (egraph_equiv_ok idx lt symbol symbol_map idx_map idx_trie analysis_result e Hok).
   Qed.
 
@@ -74,14 +81,16 @@ Import Monad.StateMonad.
     (idx_map : forall A, map.map idx A) (idx_map_ok : forall A, map.ok (idx_map A))
     (idx_trie : forall A, map.map (list idx) A) (analysis_result : Type)
     (m : model symbol)
-    (x1 x2 : idx) (e : instance idx symbol symbol_map idx_map idx_trie analysis_result)
+    (x1 x2 : idx)
     (i : idx_map (domain symbol m)) :
-    egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result e ->
-    egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i e ->
-    egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result (snd (@are_unified _ Eqb_idx _ _ _ _ _ x1 x2 e))
-    /\ egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i (snd (@are_unified _ Eqb_idx _ _ _ _ _ x1 x2 e)).
+    vc (@are_unified idx Eqb_idx symbol symbol_map idx_map idx_trie analysis_result x1 x2)
+      (fun e res =>
+         egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result e ->
+         egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i e ->
+         egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result (snd res)
+         /\ egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i (snd res)).
   Proof.
-    intros Hok Hsnd.
+    unfold vc; intros e Hok Hsnd.
     unfold are_unified.
     cbn [Mbind Mret StateMonad.state_monad].
     pose proof (@find_denote_iff idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol symbol_map idx_map idx_map_ok idx_trie analysis_result m x1 e Hok) as Hf1.
@@ -102,18 +111,20 @@ Import Monad.StateMonad.
     (symbol_map : forall A, map.map symbol A) (idx_map : forall A, map.map idx A)
     (idx_trie : forall A, map.map (list idx) A) (analysis_result : Type)
     (H : analysis idx symbol analysis_result) (m : model symbol)
-    (x : idx) (e : instance idx symbol symbol_map idx_map idx_trie analysis_result)
+    (x : idx)
     (i : idx_map (domain symbol m)) :
-    egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result e ->
-    egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i e ->
-    egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result (snd (get_analysis idx symbol symbol_map idx_map idx_trie analysis_result x e))
-    /\ egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i (snd (get_analysis idx symbol symbol_map idx_map idx_trie analysis_result x e)).
+    vc (get_analysis idx symbol symbol_map idx_map idx_trie analysis_result x)
+      (fun e res =>
+         egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result e ->
+         egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i e ->
+         egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result (snd res)
+         /\ egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i (snd res)).
   Proof.
-    intros Hok Hsnd.
+    unfold vc; intros e Hok Hsnd.
     pose proof (@get_analysis_denote_iff idx lt symbol symbol_map idx_map idx_trie analysis_result H m x e Hok) as [Hok' Hiff].
     split.
     - exact Hok'.
-    - apply Hiff. exact Hsnd.
+    - apply (Hiff i). exact Hsnd.
   Qed.
 
   Lemma eq_sound_to_domain_eq

--- a/src/Utils/EGraph/SemanticsExecConst.v
+++ b/src/Utils/EGraph/SemanticsExecConst.v
@@ -18,14 +18,14 @@ Lemma exec_write_sound
   (idx_map : forall A, map.map idx A) (idx_map_ok : forall A, map.ok (idx_map A))
   (idx_trie : forall A, map.map (list idx) A) (idx_trie_ok : forall A, map.ok (idx_trie A))
   (analysis_result : Type) (H : analysis idx symbol analysis_result) (m : model symbol)
-  (Hm_sec : model_ok symbol m)
   (Hlti : Asymmetric lt) (Hlts : forall x, lt x (idx_succ x)) (Hltt : Transitive lt)
   (Hm : model_ok symbol m)
   (i : idx_map (domain symbol m))
   (r : erule idx symbol) (assignment : list idx)
-  (e : instance idx symbol symbol_map idx_map idx_trie analysis_result)
   (a_src : idx_map (domain symbol m)) :
   let env0 := map.of_list (combine (query_vars idx symbol r) assignment) in
+  vc (exec_write idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result r assignment)
+    (fun e res =>
   List.NoDup (write_vars idx symbol r) ->
   (forall x, In x (write_vars idx symbol r) -> map.get env0 x = None) ->
   (forall x, In x (write_vars idx symbol r) ->
@@ -42,15 +42,14 @@ Lemma exec_write_sound
   all (fun p => eq_sound_for_model idx symbol idx_map m a_src (fst p) (snd p)) (write_unifications idx symbol r) ->
   egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result e ->
   egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i e ->
-  match exec_write idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result r assignment e with
-  | (_, e') =>
-      egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result e'
-      /\ (forall z, Sep.has_key z (parent (equiv e)) -> Sep.has_key z (parent (equiv e')))
+      egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result (snd res)
+      /\ (forall z, Sep.has_key z (parent (equiv e)) -> Sep.has_key z (parent (equiv (snd res))))
       /\ exists i', map.extends i' i
-                    /\ egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i' e'
-  end.
+                    /\ egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i' (snd res)).
 Proof.
-  intros env0 Hnodup Hfresh Hwf_wv Hcons Hcov_c Hcov_u Hsnd_c Hsnd_u Hok Hsnd.
+  intro env0.
+  unfold vc; intro e.
+  intros Hnodup Hfresh Hwf_wv Hcons Hcov_c Hcov_u Hsnd_c Hsnd_u Hok Hsnd.
   unfold exec_write.
   pose proof (@allocate_existential_vars_sound idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol symbol_map idx_map idx_map_ok idx_trie analysis_result m Hlti Hlts Hltt a_src (write_vars idx symbol r) i env0) as Halloc.
   unfold vc in Halloc.
@@ -124,9 +123,11 @@ Proof.
                    /\ map.get i1 v = map.get a_src x).
       { intros x Hx. destruct (Hcons_cs c (or_introl eq_refl) x Hx) as (v & Hev & Hkv & Hiv).
         exists v. split; [exact Hev|]. split; [exact (Hmono_cur v Hkv)|]. exact Hiv. }
-      pose proof (@exec_clause_sound idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol Eqb_symbol Eqb_symbol_ok symbol_map symbol_map_ok idx_map idx_map_ok idx_trie idx_trie_ok analysis_result H m Hm i1 env c a_src e_cur Hok_cur Hsnd_cur Hcc
-                    (Hsnd_cs c (or_introl eq_refl))) as Hec.
+      pose proof (@exec_clause_sound idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol Eqb_symbol Eqb_symbol_ok symbol_map symbol_map_ok idx_map idx_map_ok idx_trie idx_trie_ok analysis_result H m Hm i1 env c a_src) as Hec.
+      unfold vc in Hec. specialize (Hec e_cur).
       destruct (exec_clause idx Eqb_idx idx_zero symbol symbol_map idx_map idx_trie analysis_result env c e_cur) as [u e_mid] eqn:Hec_eq.
+      cbn [snd] in Hec.
+      specialize (Hec Hok_cur Hsnd_cur Hcc (Hsnd_cs c (or_introl eq_refl))).
       destruct Hec as (Hok_mid & Hsnd_mid & Hkeys_mid).
       pose proof (IHcs (fun c0 Hc0 => Hsnd_cs c0 (or_intror Hc0))
                        (fun c0 Hc0 => Hcons_cs c0 (or_intror Hc0))
@@ -181,11 +182,16 @@ Proof.
       cbn [Mseq Mbind Mret StateMonad.state_monad].
       rewrite Hevx, Hevy. cbn [unwrap_with_default].
       pose proof Hok_cur as Hok_cur2. destruct Hok_cur2 as [Hroots_cur _ _ _].
-      pose proof (@union_preserves_egraph_ok_sem idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol symbol_map idx_map idx_map_ok idx_trie analysis_result H vx vy e_cur Hok_cur (Hmono_cur vx Hkvx) (Hmono_cur vy Hkvy)) as Hok_mid.
-      pose proof (@union_preserves_sound_sem idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol symbol_map idx_map idx_map_ok idx_trie analysis_result H m Hm vx vy i1 e_cur Hok_cur Hsnd_cur (Hmono_cur vx Hkvx) (Hmono_cur vy Hkvy) Hequ) as Hsnd_mid.
-      pose proof (fun z Hz => @union_extends_keys_sem idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol symbol_map idx_map idx_map_ok idx_trie analysis_result H vx vy e_cur Hroots_cur (Hmono_cur vx Hkvx) (Hmono_cur vy Hkvy) z Hz) as Hkeys_mid.
+      pose proof (@union_preserves_egraph_ok_sem idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol symbol_map idx_map idx_map_ok idx_trie analysis_result H vx vy) as Hok_mid.
+      pose proof (@union_preserves_sound_sem idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol symbol_map idx_map idx_map_ok idx_trie analysis_result H m Hm vx vy i1) as Hsnd_mid.
+      pose proof (@union_extends_keys_sem idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol symbol_map idx_map idx_map_ok idx_trie analysis_result H vx vy) as Hkeys_mid.
+      unfold vc in Hok_mid, Hsnd_mid, Hkeys_mid.
+      specialize (Hok_mid e_cur). specialize (Hsnd_mid e_cur). specialize (Hkeys_mid e_cur).
       destruct (Defs.union vx vy e_cur) as [vu e_mid] eqn:Hu_eq.
       cbn [snd] in Hok_mid, Hsnd_mid, Hkeys_mid.
+      specialize (Hok_mid Hok_cur (Hmono_cur vx Hkvx) (Hmono_cur vy Hkvy)).
+      specialize (Hsnd_mid Hok_cur Hsnd_cur (Hmono_cur vx Hkvx) (Hmono_cur vy Hkvy) Hequ).
+      specialize (Hkeys_mid Hroots_cur (Hmono_cur vx Hkvx) (Hmono_cur vy Hkvy)).
       pose proof (IHps (fun p0 Hp0 => Hcons_ps p0 (or_intror Hp0)) e_mid Hok_mid Hsnd_mid
                    (fun z Hz => Hkeys_mid z (Hmono_cur z Hz))) as HIH.
       destruct (list_Miter (fun '(x,y) => Defs.union (unwrap_with_default (map.get env x)) (unwrap_with_default (map.get env y))) ps' e_mid) as [vu2 e3] eqn:Hlm3.
@@ -219,10 +225,11 @@ Section Slice.
 
   Lemma exec_const_sound
     (Hlti : Asymmetric lt) (Hlts : forall x, lt x (idx_succ x)) (Hltt : Transitive lt)
-    (Hm2 : model_ok symbol m)
     (i : idx_map (domain symbol m))
-    (r : const_rule idx symbol) (e : instance)
+    (r : const_rule idx symbol)
     (a_src : idx_map (domain symbol m)) :
+    vc (exec_const idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result r)
+      (fun e res =>
     List.NoDup (const_vars idx symbol r) ->
     (forall x, In x (const_vars idx symbol r) ->
         exists d, map.get a_src x = Some d /\ domain_wf symbol m d) ->
@@ -234,14 +241,12 @@ Section Slice.
     all (fun p => eq_sound_for_model idx symbol idx_map m a_src (fst p) (snd p)) (const_unifications idx symbol r) ->
     egraph_ok e ->
     egraph_sound_for_interpretation i e ->
-    match exec_const idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result r e with
-    | (_, e') =>
-        egraph_ok e'
-        /\ (forall z, Sep.has_key z (parent (equiv e)) -> Sep.has_key z (parent (equiv e')))
+        egraph_ok (snd res)
+        /\ (forall z, Sep.has_key z (parent (equiv e)) -> Sep.has_key z (parent (equiv (snd res))))
         /\ exists i', map.extends i' i
-                      /\ egraph_sound_for_interpretation i' e'
-    end.
+                      /\ egraph_sound_for_interpretation i' (snd res)).
   Proof.
+    unfold vc; intro e.
     intros Hnodup Hwf_wv Hcov_c Hcov_u Hsnd_c Hsnd_u Hok Hsnd.
     unfold exec_const.
     pose proof (@allocate_existential_vars_sound idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol symbol_map idx_map idx_map_ok idx_trie analysis_result m Hlti Hlts Hltt a_src (const_vars idx symbol r) i map.empty) as Halloc.
@@ -306,9 +311,11 @@ Section Slice.
                          /\ map.get i1 v = map.get a_src x)
               by (intros x Hx; destruct (Hcons_cs c (or_introl eq_refl) x Hx) as (v & Hev & Hkv & Hiv);
                   exists v; split; [exact Hev|]; split; [exact (Hmono_cur v Hkv)|]; exact Hiv);
-            pose proof (@exec_clause_sound idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol Eqb_symbol Eqb_symbol_ok symbol_map symbol_map_ok idx_map idx_map_ok idx_trie idx_trie_ok analysis_result H m Hm i1 env c a_src e_cur Hok_cur Hsnd_cur Hcc
-                          (Hsnd_cs c (or_introl eq_refl))) as Hec;
+            pose proof (@exec_clause_sound idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol Eqb_symbol Eqb_symbol_ok symbol_map symbol_map_ok idx_map idx_map_ok idx_trie idx_trie_ok analysis_result H m Hm i1 env c a_src) as Hec;
+            unfold vc in Hec; specialize (Hec e_cur);
             destruct (exec_clause idx Eqb_idx idx_zero symbol symbol_map idx_map idx_trie analysis_result env c e_cur) as [u e_mid] eqn:Hec_eq;
+            cbn [snd] in Hec;
+            specialize (Hec Hok_cur Hsnd_cur Hcc (Hsnd_cs c (or_introl eq_refl)));
             destruct Hec as (Hok_mid & Hsnd_mid & Hkeys_mid);
             pose proof (IHcs (fun c0 Hc0 => Hsnd_cs c0 (or_intror Hc0))
                              (fun c0 Hc0 => Hcons_cs c0 (or_intror Hc0))
@@ -361,11 +368,16 @@ Section Slice.
             cbn [Mseq Mbind Mret StateMonad.state_monad];
             rewrite Hevx, Hevy; cbn [unwrap_with_default];
             pose proof Hok_cur as Hok_cur2; destruct Hok_cur2 as [Hroots_cur _ _ _];
-            pose proof (@union_preserves_egraph_ok_sem idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol symbol_map idx_map idx_map_ok idx_trie analysis_result H vx vy e_cur Hok_cur (Hmono_cur vx Hkvx) (Hmono_cur vy Hkvy)) as Hok_mid;
-            pose proof (@union_preserves_sound_sem idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol symbol_map idx_map idx_map_ok idx_trie analysis_result H m Hm vx vy i1 e_cur Hok_cur Hsnd_cur (Hmono_cur vx Hkvx) (Hmono_cur vy Hkvy) Hequ) as Hsnd_mid;
-            pose proof (fun z Hz => @union_extends_keys_sem idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol symbol_map idx_map idx_map_ok idx_trie analysis_result H vx vy e_cur Hroots_cur (Hmono_cur vx Hkvx) (Hmono_cur vy Hkvy) z Hz) as Hkeys_mid;
+            pose proof (@union_preserves_egraph_ok_sem idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol symbol_map idx_map idx_map_ok idx_trie analysis_result H vx vy) as Hok_mid;
+            pose proof (@union_preserves_sound_sem idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol symbol_map idx_map idx_map_ok idx_trie analysis_result H m Hm vx vy i1) as Hsnd_mid;
+            pose proof (@union_extends_keys_sem idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol symbol_map idx_map idx_map_ok idx_trie analysis_result H vx vy) as Hkeys_mid;
+            unfold vc in Hok_mid, Hsnd_mid, Hkeys_mid;
+            specialize (Hok_mid e_cur); specialize (Hsnd_mid e_cur); specialize (Hkeys_mid e_cur);
             destruct (Defs.union vx vy e_cur) as [vu e_mid] eqn:Hu_eq;
             cbn [snd] in Hok_mid, Hsnd_mid, Hkeys_mid;
+            specialize (Hok_mid Hok_cur (Hmono_cur vx Hkvx) (Hmono_cur vy Hkvy));
+            specialize (Hsnd_mid Hok_cur Hsnd_cur (Hmono_cur vx Hkvx) (Hmono_cur vy Hkvy) Hequ);
+            specialize (Hkeys_mid Hroots_cur (Hmono_cur vx Hkvx) (Hmono_cur vy Hkvy));
             pose proof (IHps (fun p0 Hp0 => Hcons_ps p0 (or_intror Hp0)) e_mid Hok_mid Hsnd_mid
                          (fun z Hz => Hkeys_mid z (Hmono_cur z Hz))) as HIH;
             destruct (list_Miter (fun '(x,y) => Defs.union (unwrap_with_default (map.get env x)) (unwrap_with_default (map.get env y))) ps' e_mid) as [vu2 e3] eqn:Hlm3;
@@ -390,17 +402,18 @@ Section Slice.
 
   Lemma process_const_rules_sound
     (Hlti : Asymmetric lt) (Hlts : forall x, lt x (idx_succ x)) (Hltt : Transitive lt)
-    (Hm2 : model_ok symbol m)
     (rs : rule_set idx symbol symbol_map idx_map)
     (Hcr : forall r, In r (compiled_const_rules idx symbol symbol_map idx_map rs) -> exists a_src, const_rule_sound a_src r) :
-    forall (i : idx_map (domain symbol m)) e,
+    forall (i : idx_map (domain symbol m)),
+      vc (process_const_rules idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result rs)
+        (fun e res =>
       egraph_ok e ->
       egraph_sound_for_interpretation i e ->
-      egraph_ok (snd (process_const_rules idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result rs e))
+      egraph_ok (snd res)
       /\ exists i', map.extends i' i
-                    /\ egraph_sound_for_interpretation i' (snd (process_const_rules idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result rs e)).
+                    /\ egraph_sound_for_interpretation i' (snd res)).
   Proof.
-    intros i e Hok Hsnd.
+    intros i. unfold vc; intro e. intros Hok Hsnd.
     unfold process_const_rules.
     set (crs := compiled_const_rules idx symbol symbol_map idx_map rs).
     assert (Hcr' : forall r, In r crs -> exists a_src, const_rule_sound a_src r)
@@ -413,9 +426,11 @@ Section Slice.
       exists i. split; [apply Properties.map.extends_refl|exact Hsnd].
     - cbn [list_Miter Mbind Mret StateMonad.state_monad fst snd].
       destruct (Hcr' cr (or_introl eq_refl)) as (a_src & Hnd & Hwf & Hcov_c & Hcov_u & Hsnd_c & Hsnd_u).
-      pose proof (exec_const_sound Hlti Hlts Hltt Hm2 i cr e a_src Hnd Hwf Hcov_c Hcov_u Hsnd_c Hsnd_u Hok Hsnd) as Hec.
+      pose proof (exec_const_sound Hlti Hlts Hltt i cr a_src) as Hec.
+      unfold vc in Hec. specialize (Hec e).
       destruct (exec_const idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result cr e) as [u1 e1] eqn:Hec_eq.
       cbn [fst snd] in Hec.
+      specialize (Hec Hnd Hwf Hcov_c Hcov_u Hsnd_c Hsnd_u Hok Hsnd).
       destruct Hec as (Hok1 & _Hmono1 & i1 & Hext1 & Hsnd1).
       assert (Hcr'_tail : forall r, In r crs' -> exists a_src, const_rule_sound a_src r)
         by (intros r Hr; exact (Hcr' r (or_intror Hr))).

--- a/src/Utils/EGraph/SemanticsLSurvive.v
+++ b/src/Utils/EGraph/SemanticsLSurvive.v
@@ -89,16 +89,19 @@ Section Slice.
      (all-root args + root ret) wrt [eF].  (T) transports [a]'s up-to-equiv
      presence from [e] to [eF] (and gives [egraph_ok eF]); (F) then materialises
      the verbatim canonical [a] in [eF].  The caller (add_ctx discharge) supplies
-     [db_inv (True) eF] and the eF-canonicality from the known add_ctx structure. *)
-  Lemma L_survive_canonical' n (e : instance) (a : atom)
-    : egraph_ok e ->
-      atom_in_egraph_up_to_equiv a e ->
-      db_inv (fun _ => True) (snd (rebuild n e)) ->
-      all (fun x => map.get (snd (rebuild n e)).(equiv).(parent) x = Some x) a.(atom_args) ->
-      map.get (snd (rebuild n e)).(equiv).(parent) a.(atom_ret) = Some a.(atom_ret) ->
-      atom_in_egraph a (snd (rebuild n e)).
+     [db_inv (True) eF] and the eF-canonicality from the known add_ctx structure.
+     Stated as a [vc (rebuild n)] characterizing the post-state [eF := snd res]. *)
+  Lemma L_survive_canonical' n (a : atom)
+    : vc (rebuild n)
+        (fun e res =>
+           egraph_ok e ->
+           atom_in_egraph_up_to_equiv a e ->
+           db_inv (fun _ => True) (snd res) ->
+           all (fun x => map.get (snd res).(equiv).(parent) x = Some x) a.(atom_args) ->
+           map.get (snd res).(equiv).(parent) a.(atom_ret) = Some a.(atom_ret) ->
+           atom_in_egraph a (snd res)).
   Proof.
-    intros Hok Hup Hinv Hargs Hret.
+    unfold vc; intros e Hok Hup Hinv Hargs Hret.
     destruct (rebuild_survives_side (a :: nil) n e Hok (conj Hup I)) as [Hok_F Hall_F].
     cbn [all] in Hall_F. destruct Hall_F as [Hup_F _].
     eapply canonical_uptoequiv_present;

--- a/src/Utils/EGraph/SemanticsProcessErule.v
+++ b/src/Utils/EGraph/SemanticsProcessErule.v
@@ -85,7 +85,12 @@ Section Slice.
                     (nth cv clause_vars idx_zero)).
   Proof.
     intros Hsnd Hnd Hlen Ha_q Hqf Hclause Hcvars Hbound_args Hbound_cv Hhit.
-    pose proof (clause_ptr_atom_in_db q inst query_vars frontier_n f n clause_vars q_f (cargs,cv) sigma Hqf Hclause Hhit) as Hcp.
+    pose proof (clause_ptr_atom_in_db q query_vars frontier_n f n clause_vars q_f (cargs,cv) sigma) as Hcp0.
+    unfold vc in Hcp0. specialize (Hcp0 inst).
+    destruct (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
+                idx_map idx_map_plus idx_trie analysis_result window q inst) as [bt_v bt_s] eqn:Hbt.
+    cbn [fst snd] in Hcp0, Hhit.
+    pose proof (Hcp0 Hqf Hclause Hhit) as Hcp.
     destruct Hcp as [ args_db [ v_db [ Hdb Hmatch ] ] ].
     set (proj := map fst (filter snd (combine sigma (variable_flags idx Eqb_idx query_vars clause_vars)))) in *.
     pose proof (atom_interpretation m i inst Hsnd (Build_atom f args_db v_db) Hdb) as Hdb_snd.
@@ -171,7 +176,12 @@ Section Slice.
                     (nth cv clause_vars idx_zero)).
   Proof.
     intros Hsnd Hnd Hlen Ha_q Hqf Hclause Hcvars Hbound_args Hbound_cv Hhit.
-    pose proof (clause_ptr_atom_in_db_sn q inst query_vars frontier_pos pos f n clause_vars q_f (cargs,cv) sigma Hqf Hclause Hhit) as Hcp.
+    pose proof (clause_ptr_atom_in_db_sn q query_vars frontier_pos pos f n clause_vars q_f (cargs,cv) sigma) as Hcp0.
+    unfold vc in Hcp0. specialize (Hcp0 inst).
+    destruct (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
+                idx_map idx_map_plus idx_trie analysis_result window q inst) as [bt_v bt_s] eqn:Hbt.
+    cbn [fst snd] in Hcp0, Hhit.
+    pose proof (Hcp0 Hqf Hclause Hhit) as Hcp.
     destruct Hcp as [ args_db [ v_db [ Hdb Hmatch ] ] ].
     set (proj := map fst (filter snd (combine sigma (variable_flags idx Eqb_idx query_vars clause_vars)))) in *.
     pose proof (atom_interpretation m i inst Hsnd (Build_atom f args_db v_db) Hdb) as Hdb_snd.
@@ -448,18 +458,18 @@ Section Slice.
                       (map fst (filter snd (combine sigma
                          (variable_flags idx Eqb_idx (query_vars idx symbol r) cvars))))
               = Some tt)) ->
-    forall e_cur icur,
-      egraph_ok e_cur -> egraph_sound_for_interpretation icur e_cur -> map.extends icur i_snap ->
-    match list_Miter (exec_write idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result r) sigmas e_cur with
-    | (_, e') =>
-        egraph_ok e'
-        /\ exists i', map.extends i' i_snap /\ egraph_sound_for_interpretation i' e'
-    end.
+    vc (list_Miter (exec_write idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result r) sigmas)
+      (fun e_cur res =>
+       forall icur,
+         egraph_ok e_cur -> egraph_sound_for_interpretation icur e_cur -> map.extends icur i_snap ->
+         egraph_ok (snd res)
+         /\ exists i', map.extends i' i_snap /\ egraph_sound_for_interpretation i' (snd res)).
   Proof.
     intros db_tries Hsnd_inst Hnd_qv Hnd_wv Hrule Hwf Hcov Hdisj HcovC HcovU.
     intro sigmas. induction sigmas as [|sigma sigmas' IH];
-      intros Hprem e_cur icur Hok_cur Hsnd_cur Hext_cur.
-    - cbn [list_Miter]. split; [exact Hok_cur|].
+      intros Hprem; unfold vc; intro e_cur; cbn beta;
+      intros icur Hok_cur Hsnd_cur Hext_cur.
+    - cbn [list_Miter Mret StateMonad.state_monad fst snd]. split; [exact Hok_cur|].
       exists icur. split; [exact Hext_cur | exact Hsnd_cur].
     - cbn [list_Miter].
       destruct (Hprem sigma (or_introl eq_refl)) as (frontier_n & Hlen1 & Hsli_sigma).
@@ -505,19 +515,22 @@ Section Slice.
               [ left; exists (named_list_lookup idx_zero (combine (query_vars idx symbol r) sigma) (snd p));
                 unfold env0; exact (get_of_list_combine idx idx_zero (query_vars idx symbol r) sigma (snd p) Hnd_qv Hlen1 Hq)
               | right; exact Hw ] ]).
-      pose proof (@exec_write_sound idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol Eqb_symbol Eqb_symbol_ok symbol_map symbol_map_ok idx_map idx_map_ok idx_trie idx_trie_ok analysis_result H m Hm Hlti Hlts Hltt Hm icur r sigma e_cur a_src
-                    Hnd_wv Hfresh Hsrc_wv Hcons Hcons_c Hcons_u Hsrc_c Hsrc_u Hok_cur Hsnd_cur) as Hew.
+      pose proof (@exec_write_sound idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol Eqb_symbol Eqb_symbol_ok symbol_map symbol_map_ok idx_map idx_map_ok idx_trie idx_trie_ok analysis_result H m Hlti Hlts Hltt Hm icur r sigma a_src) as Hew.
+      cbv zeta in Hew. unfold vc in Hew. specialize (Hew e_cur).
       cbn [Mseq Mbind Mret StateMonad.state_monad].
       destruct (exec_write idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result r sigma e_cur)
         as [u e_mid] eqn:Hew_eq.
+      cbn [fst snd] in Hew.
+      specialize (Hew Hnd_wv Hfresh Hsrc_wv Hcons Hcons_c Hcons_u Hsrc_c Hsrc_u Hok_cur Hsnd_cur).
       destruct Hew as (Hok_mid & _Hmono & i_mid & Hext_mid & Hsnd_mid).
       assert (Hext_mid_i : map.extends i_mid i_snap)
         by (intros k vv hh; apply Hext_mid; apply Hext_cur; exact hh).
-      pose proof (IH (fun s Hs => Hprem s (or_intror Hs))
-                    e_mid i_mid Hok_mid Hsnd_mid Hext_mid_i) as HIH.
+      pose proof (IH (fun s Hs => Hprem s (or_intror Hs))) as HIH0.
+      unfold vc in HIH0. specialize (HIH0 e_mid i_mid Hok_mid Hsnd_mid Hext_mid_i).
       destruct (list_Miter (exec_write idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result r) sigmas' e_mid)
         as [u2 e'] eqn:Hlm.
-      destruct HIH as (Hok' & i' & Hext'_snap & Hsnd').
+      cbn [fst snd] in HIH0 |- *.
+      destruct HIH0 as (Hok' & i' & Hext'_snap & Hsnd').
       split; [exact Hok'|].
       exists i'. split; [exact Hext'_snap | exact Hsnd'].
   Qed.
@@ -534,16 +547,13 @@ Section Slice.
     (Hlti : Asymmetric lt) (Hlts : forall x, lt x (idx_succ x)) (Hltt : Transitive lt)
     (i_snap i_start : idx_map (domain symbol m)) (inst : instance)
     (q : rule_set idx symbol symbol_map idx_map) (r : erule idx symbol)
-    (frontier_n : idx) (e_start : instance) :
+    (frontier_n : idx) :
     let db_tries := fst (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
                            idx_map idx_map_plus idx_trie analysis_result window q inst) in
     let tries := ne_map (trie_of_clause idx Eqb_idx symbol symbol_map idx_map idx_trie
                            (query_vars idx symbol r) db_tries frontier_n)
                         (query_clause_ptrs idx symbol r) in
     egraph_sound_for_interpretation i_snap inst ->
-    egraph_ok e_start ->
-    egraph_sound_for_interpretation i_start e_start ->
-    map.extends i_start i_snap ->
     List.NoDup (query_vars idx symbol r) ->
     List.NoDup (write_vars idx symbol r) ->
     erule_sound idx idx_zero symbol symbol_map idx_map m (query_clauses idx symbol symbol_map idx_map q) r ->
@@ -578,15 +588,18 @@ Section Slice.
                (map fst (filter snd (combine sigma
                   (variable_flags idx Eqb_idx (query_vars idx symbol r) cvars))))
        = Some tt) ->
-    match @process_erule' idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie
-            analysis_result _ spaced_list_intersect db_tries r frontier_n e_start with
-    | (_, e') =>
-        egraph_ok e'
-        /\ exists i', map.extends i' i_snap /\ egraph_sound_for_interpretation i' e'
-    end.
+    vc (@process_erule' idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie
+            analysis_result _ spaced_list_intersect db_tries r frontier_n)
+      (fun e_start res =>
+         egraph_ok e_start ->
+         egraph_sound_for_interpretation i_start e_start ->
+         map.extends i_start i_snap ->
+         egraph_ok (snd res)
+         /\ exists i', map.extends i' i_snap /\ egraph_sound_for_interpretation i' (snd res)).
   Proof.
-    intros db_tries tries Hsnd_inst Hok_start Hsnd_start Hext_start Hnd_qv Hnd_wv Hrule
+    intros db_tries tries Hsnd_inst Hnd_qv Hnd_wv Hrule
            Hwf Hcov Hdisj HcovC HcovU Hlen_sig Hsli.
+    unfold vc; intro e_start; cbn beta; intros Hok_start Hsnd_start Hext_start.
     unfold process_erule'.
     fold tries.
     set (asn := intersection_keys idx idx_trie spaced_list_intersect tries) in *.
@@ -648,11 +661,13 @@ Section Slice.
                 [ left; exists (named_list_lookup idx_zero (combine (query_vars idx symbol r) sigma) (snd p));
                   unfold env0; exact (get_of_list_combine idx idx_zero (query_vars idx symbol r) sigma (snd p) Hnd_qv Hlen1 Hq)
                 | right; exact Hw ] ]).
-        pose proof (@exec_write_sound idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol Eqb_symbol Eqb_symbol_ok symbol_map symbol_map_ok idx_map idx_map_ok idx_trie idx_trie_ok analysis_result H m Hm Hlti Hlts Hltt Hm icur r sigma e_cur a_src
-                      Hnd_wv Hfresh Hsrc_wv Hcons Hcons_c Hcons_u Hsrc_c Hsrc_u Hok_cur Hsnd_cur) as Hew.
+        pose proof (@exec_write_sound idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol Eqb_symbol Eqb_symbol_ok symbol_map symbol_map_ok idx_map idx_map_ok idx_trie idx_trie_ok analysis_result H m Hlti Hlts Hltt Hm icur r sigma a_src) as Hew.
+        cbv zeta in Hew. unfold vc in Hew. specialize (Hew e_cur).
         cbn [Mseq Mbind Mret StateMonad.state_monad].
         destruct (exec_write idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result r sigma e_cur)
           as [u e_mid] eqn:Hew_eq.
+        cbn [fst snd] in Hew.
+        specialize (Hew Hnd_wv Hfresh Hsrc_wv Hcons Hcons_c Hcons_u Hsrc_c Hsrc_u Hok_cur Hsnd_cur).
         destruct Hew as (Hok_mid & _Hmono & i_mid & Hext_mid & Hsnd_mid).
         assert (Hext_mid_i : map.extends i_mid i_snap)
           by (intros k vv hh; apply Hext_mid; apply Hext_cur; exact hh).
@@ -663,7 +678,10 @@ Section Slice.
         destruct HIH as (Hok' & i' & Hext'_snap & Hsnd').
         split; [exact Hok'|].
         exists i'. split; [exact Hext'_snap | exact Hsnd']. }
-    apply (Hloop asn Hlen_sig Hsli e_start i_start Hok_start Hsnd_start Hext_start).
+    pose proof (Hloop asn Hlen_sig Hsli e_start i_start Hok_start Hsnd_start Hext_start) as Hfin.
+    destruct (list_Miter (exec_write idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result r) asn e_start)
+      as [u e'] eqn:Hlmf.
+    cbn [fst snd]. exact Hfin.
   Qed.
 
   (* Proper semi-naive soundness for one frontier POSITION of a single erule:
@@ -676,7 +694,7 @@ Section Slice.
     (Hlti : Asymmetric lt) (Hlts : forall x, lt x (idx_succ x)) (Hltt : Transitive lt)
     (i_snap i_start : idx_map (domain symbol m)) (inst : instance)
     (q : rule_set idx symbol symbol_map idx_map) (r : erule idx symbol)
-    (frontier_pos : nat) (e_start : instance) :
+    (frontier_pos : nat) :
     let db_tries := fst (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
                            idx_map idx_map_plus idx_trie analysis_result window q inst) in
     let tries := ne_map_idx (fun pos ptr =>
@@ -684,9 +702,6 @@ Section Slice.
                                  (query_vars idx symbol r) db_tries frontier_pos pos ptr)
                             (query_clause_ptrs idx symbol r) in
     egraph_sound_for_interpretation i_snap inst ->
-    egraph_ok e_start ->
-    egraph_sound_for_interpretation i_start e_start ->
-    map.extends i_start i_snap ->
     List.NoDup (query_vars idx symbol r) ->
     List.NoDup (write_vars idx symbol r) ->
     erule_sound idx idx_zero symbol symbol_map idx_map m (query_clauses idx symbol symbol_map idx_map q) r ->
@@ -721,15 +736,18 @@ Section Slice.
                (map fst (filter snd (combine sigma
                   (variable_flags idx Eqb_idx (query_vars idx symbol r) cvars))))
        = Some tt) ->
-    match @process_erule'_sn idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie
-            analysis_result _ spaced_list_intersect db_tries r frontier_pos e_start with
-    | (_, e') =>
-        egraph_ok e'
-        /\ exists i', map.extends i' i_snap /\ egraph_sound_for_interpretation i' e'
-    end.
+    vc (@process_erule'_sn idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie
+            analysis_result _ spaced_list_intersect db_tries r frontier_pos)
+      (fun e_start res =>
+         egraph_ok e_start ->
+         egraph_sound_for_interpretation i_start e_start ->
+         map.extends i_start i_snap ->
+         egraph_ok (snd res)
+         /\ exists i', map.extends i' i_snap /\ egraph_sound_for_interpretation i' (snd res)).
   Proof.
-    intros db_tries tries Hsnd_inst Hok_start Hsnd_start Hext_start Hnd_qv Hnd_wv Hrule
+    intros db_tries tries Hsnd_inst Hnd_qv Hnd_wv Hrule
            Hwf Hcov Hdisj HcovC HcovU Hlen_sig Hsli.
+    unfold vc; intro e_start; cbn beta; intros Hok_start Hsnd_start Hext_start.
     unfold process_erule'_sn.
     fold tries.
     set (asn := intersection_keys idx idx_trie spaced_list_intersect tries) in *.
@@ -793,11 +811,13 @@ Section Slice.
                 [ left; exists (named_list_lookup idx_zero (combine (query_vars idx symbol r) sigma) (snd p));
                   unfold env0; exact (get_of_list_combine idx idx_zero (query_vars idx symbol r) sigma (snd p) Hnd_qv Hlen1 Hq)
                 | right; exact Hw ] ]).
-        pose proof (@exec_write_sound idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol Eqb_symbol Eqb_symbol_ok symbol_map symbol_map_ok idx_map idx_map_ok idx_trie idx_trie_ok analysis_result H m Hm Hlti Hlts Hltt Hm icur r sigma e_cur a_src
-                      Hnd_wv Hfresh Hsrc_wv Hcons Hcons_c Hcons_u Hsrc_c Hsrc_u Hok_cur Hsnd_cur) as Hew.
+        pose proof (@exec_write_sound idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol Eqb_symbol Eqb_symbol_ok symbol_map symbol_map_ok idx_map idx_map_ok idx_trie idx_trie_ok analysis_result H m Hlti Hlts Hltt Hm icur r sigma a_src) as Hew.
+        cbv zeta in Hew. unfold vc in Hew. specialize (Hew e_cur).
         cbn [Mseq Mbind Mret StateMonad.state_monad].
         destruct (exec_write idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result r sigma e_cur)
           as [u e_mid] eqn:Hew_eq.
+        cbn [fst snd] in Hew.
+        specialize (Hew Hnd_wv Hfresh Hsrc_wv Hcons Hcons_c Hcons_u Hsrc_c Hsrc_u Hok_cur Hsnd_cur).
         destruct Hew as (Hok_mid & _Hmono & i_mid & Hext_mid & Hsnd_mid).
         assert (Hext_mid_i : map.extends i_mid i_snap)
           by (intros k vv hh; apply Hext_mid; apply Hext_cur; exact hh).
@@ -808,7 +828,10 @@ Section Slice.
         destruct HIH as (Hok' & i' & Hext'_snap & Hsnd').
         split; [exact Hok'|].
         exists i'. split; [exact Hext'_snap | exact Hsnd']. }
-    apply (Hloop asn Hlen_sig Hsli e_start i_start Hok_start Hsnd_start Hext_start).
+    pose proof (Hloop asn Hlen_sig Hsli e_start i_start Hok_start Hsnd_start Hext_start) as Hfin.
+    destruct (list_Miter (exec_write idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result r) asn e_start)
+      as [u e'] eqn:Hlmf.
+    cbn [fst snd]. exact Hfin.
   Qed.
 
 End Slice.
@@ -836,14 +859,10 @@ Lemma process_erule_sound
   (window : nat)
   (i_snap i_start : idx_map (domain symbol m))
   (inst : instance idx symbol symbol_map idx_map idx_trie analysis_result)
-  (q : rule_set idx symbol symbol_map idx_map) (r : erule idx symbol)
-  (e_start : instance idx symbol symbol_map idx_map idx_trie analysis_result) :
+  (q : rule_set idx symbol symbol_map idx_map) (r : erule idx symbol) :
   let db_tries := fst (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus
                          idx_map idx_map_plus idx_trie analysis_result window q inst) in
   egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i_snap inst ->
-  egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result e_start ->
-  egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i_start e_start ->
-  map.extends i_start i_snap ->
   List.NoDup (query_vars idx symbol r) ->
   List.NoDup (write_vars idx symbol r) ->
   erule_sound idx idx_zero symbol symbol_map idx_map m (query_clauses idx symbol symbol_map idx_map q) r ->
@@ -888,16 +907,19 @@ Lemma process_erule_sound
              (map fst (filter snd (combine sigma
                 (variable_flags idx Eqb_idx (query_vars idx symbol r) cvars))))
      = Some tt) ->
-  match @process_erule idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie
-          analysis_result _ spaced_list_intersect db_tries r e_start with
-  | (_, e') =>
-      egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result e'
-      /\ exists i', map.extends i' i_snap
-                    /\ egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i' e'
-  end.
+  vc (@process_erule idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie
+          analysis_result _ spaced_list_intersect db_tries r)
+    (fun e_start res =>
+       egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result e_start ->
+       egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i_start e_start ->
+       map.extends i_start i_snap ->
+       egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result (snd res)
+       /\ exists i', map.extends i' i_snap
+                     /\ egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i' (snd res)).
 Proof.
-  intros db_tries Hsnd_inst Hok_start Hsnd_start Hext_start Hnd_qv Hnd_wv Hrule
+  intros db_tries Hsnd_inst Hnd_qv Hnd_wv Hrule
          Hwf Hcov Hdisj HcovC HcovU Hlen_sig Hsli.
+  unfold vc; intro e_start; cbn beta; intros Hok_start Hsnd_start Hext_start.
   (* The proper semi-naive [process_erule] iterates [process_erule'_sn] over the
      frontier positions [seq 0 nclauses], threading the egraph.  Each position is
      sound by [process_erule'_sn_sound] (fixed snapshot [i_snap], evolving loop
@@ -919,15 +941,18 @@ Proof.
     - cbn [list_Miter]. split; [exact Hok_cur|].
       exists icur. split; [exact Hext_cur | exact Hsnd_cur].
     - cbn [list_Miter].
-      pose proof (process_erule'_sn_sound window Hlti Hlts Hltt i_snap icur inst q r p e_cur
-                    Hsnd_inst Hok_cur Hsnd_cur Hext_cur Hnd_qv Hnd_wv Hrule
+      pose proof (process_erule'_sn_sound window Hlti Hlts Hltt i_snap icur inst q r p
+                    Hsnd_inst Hnd_qv Hnd_wv Hrule
                     Hwf Hcov Hdisj HcovC HcovU (Hlen_sig p) (Hsli p)) as Hstep.
       cbv zeta in Hstep.
       fold db_tries in Hstep.
+      unfold vc in Hstep. specialize (Hstep e_cur).
       cbn [Mseq Mbind Mret StateMonad.state_monad].
       destruct (@process_erule'_sn idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie
                   analysis_result _ spaced_list_intersect db_tries r p e_cur)
         as [u e_mid] eqn:Hpe.
+      cbn [fst snd] in Hstep.
+      specialize (Hstep Hok_cur Hsnd_cur Hext_cur).
       destruct Hstep as (Hok_mid & i_mid & Hext_mid & Hsnd_mid).
       pose proof (IH e_mid i_mid Hok_mid Hsnd_mid Hext_mid) as HIH.
       destruct (list_Miter (@process_erule'_sn idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie
@@ -936,5 +961,10 @@ Proof.
       destruct HIH as (Hok' & i' & Hext'_snap & Hsnd').
       split; [exact Hok'|].
       exists i'. split; [exact Hext'_snap | exact Hsnd']. }
-  apply (Hloop _ e_start i_start Hok_start Hsnd_start Hext_start).
+  lazymatch goal with
+  | |- context [ list_Miter ?f ?l ?s ] =>
+      pose proof (Hloop l e_start i_start Hok_start Hsnd_start Hext_start) as Hfin;
+      destruct (list_Miter f l s) as [u e'] eqn:Hlmf
+  end.
+  cbn [fst snd]. exact Hfin.
 Qed.

--- a/src/Utils/EGraph/SemanticsRebuildCanon.v
+++ b/src/Utils/EGraph/SemanticsRebuildCanon.v
@@ -35,7 +35,11 @@ Proof.
       cbn [list_Mmap canonicalize_worklist_entry Mbind Mret StateMonad.state_monad fst snd].
       assert (Hnew_root : map.get e.(equiv).(parent) new_idx = Some new_idx).
       { apply (Hroots_e old new_idx b). left. reflexivity. }
-      rewrite (@find_root_identity _ _ _ _ _ _ _ _ e new_idx Hnew_root).
+      pose proof (find_root_identity
+                    idx Eqb_idx Eqb_idx_ok symbol symbol_map idx_map idx_trie
+                    analysis_result new_idx) as Hfri.
+      unfold vc in Hfri. specialize (Hfri e).
+      rewrite (Hfri Hnew_root).
       unfold vc in IH. specialize (IH e).
       assert (Hroots_tail : forall old0 new_idx0 b0, In (@union_repair idx old0 new_idx0 b0) l ->
                   map.get e.(equiv).(parent) new_idx0 = Some new_idx0).
@@ -89,16 +93,18 @@ Lemma rebuild_canon
   (idx_trie : forall A, map.map (list idx) A) (idx_trie_ok : forall A, map.ok (idx_trie A))
   (analysis_result : Type) (HA : analysis idx symbol analysis_result)
   (m : model symbol) (Hm : model_ok symbol m)
-  fuel e1 ed_list
-  : @egraph_ok _ lt _ _ _ _ _ e1 ->
-    good_worklist idx symbol symbol_map idx_map idx_trie analysis_result e1 ed_list ->
-    @db_inv _ _ _ _ _ _ (fun _ => True) (snd (rebuild (S fuel) e1))
-    /\ (forall z, @is_root _ _ _ _ _ _ e1 z -> @is_root _ _ _ _ _ _ (snd (rebuild (S fuel) e1)) z)
-    /\ (forall b, @atom_in_db _ _ _ _ _ b (snd (rebuild (S fuel) e1)).(db) ->
-           exists a, @atom_in_db _ _ _ _ _ a e1.(db)
-             /\ a.(atom_fn) = b.(atom_fn) /\ a.(atom_args) = b.(atom_args)).
+  fuel ed_list
+  : vc (rebuild (S fuel))
+      (fun e1 res =>
+         @egraph_ok _ lt _ _ _ _ _ e1 ->
+         good_worklist idx symbol symbol_map idx_map idx_trie analysis_result e1 ed_list ->
+         @db_inv _ _ _ _ _ _ (fun _ => True) (snd res)
+         /\ (forall z, @is_root _ _ _ _ _ _ e1 z -> @is_root _ _ _ _ _ _ (snd res) z)
+         /\ (forall b, @atom_in_db _ _ _ _ _ b (snd res).(db) ->
+                exists a, @atom_in_db _ _ _ _ _ a e1.(db)
+                  /\ a.(atom_fn) = b.(atom_fn) /\ a.(atom_args) = b.(atom_args))).
 Proof.
-  intros Hok1 Hgwl.
+  unfold vc; intros e1 Hok1 Hgwl.
   destruct Hgwl as (Hwl_eq & Hnodup & Hall_good & Hdisj & Hdbinv & Hcov).
   cbn [rebuild].
   unfold pull_worklist. cbn [Mbind StateMonad.state_monad fst snd].

--- a/src/Utils/EGraph/SemanticsSaturate.v
+++ b/src/Utils/EGraph/SemanticsSaturate.v
@@ -50,10 +50,13 @@ Section Slice.
     (egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m).
 
   (* increment_epoch_preserves *)
-  Lemma increment_epoch_preserves (e : instance) :
-    (egraph_ok e -> egraph_ok (snd (increment_epoch idx idx_succ symbol symbol_map idx_map idx_trie analysis_result e)))
-    /\ (forall i, egraph_sound_for_interpretation i e -> egraph_sound_for_interpretation i (snd (increment_epoch idx idx_succ symbol symbol_map idx_map idx_trie analysis_result e))).
+  Lemma increment_epoch_preserves :
+    vc (increment_epoch idx idx_succ symbol symbol_map idx_map idx_trie analysis_result)
+      (fun e res =>
+         (egraph_ok e -> egraph_ok (snd res))
+         /\ (forall i, egraph_sound_for_interpretation i e -> egraph_sound_for_interpretation i (snd res))).
   Proof.
+    unfold vc; intro e.
     destruct e as [db equiv parents epoch worklist analyses log].
     cbn [increment_epoch snd].
     split.
@@ -128,28 +131,27 @@ Section Slice.
     (Hlti : Asymmetric lt) (Hlts : forall x, lt x (idx_succ x)) (Hltt : Transitive lt)
     (rebuild_fuel : nat) (window : nat)
     (i_0 : idx_map (domain symbol m))
-    (rs : rule_set idx symbol symbol_map idx_map)
-    (e_0 : instance) :
-    egraph_ok e_0 ->
-    egraph_sound_for_interpretation i_0 e_0 ->
-    (forall r, In r (compiled_rules idx symbol symbol_map idx_map rs) ->
-       run1iter_rule_hyps idx Eqb_idx idx_zero idx_succ idx_leb window symbol symbol_map symbol_map_plus
-         idx_map idx_map_plus idx_trie analysis_result spaced_list_intersect m rs e_0 r) ->
-    match Defs.run1iter idx Eqb_idx idx_succ idx_zero idx_leb symbol symbol_map symbol_map_plus
-            idx_map idx_map_plus idx_trie analysis_result spaced_list_intersect rebuild_fuel window rs e_0 with
-    | (_, e') => egraph_ok e' /\ exists i', map.extends i' i_0 /\ egraph_sound_for_interpretation i' e'
-    end.
+    (rs : rule_set idx symbol symbol_map idx_map) :
+    vc (Defs.run1iter idx Eqb_idx idx_succ idx_zero idx_leb symbol symbol_map symbol_map_plus
+          idx_map idx_map_plus idx_trie analysis_result spaced_list_intersect rebuild_fuel window rs)
+      (fun e_0 res =>
+         egraph_ok e_0 ->
+         egraph_sound_for_interpretation i_0 e_0 ->
+         (forall r, In r (compiled_rules idx symbol symbol_map idx_map rs) ->
+            run1iter_rule_hyps idx Eqb_idx idx_zero idx_succ idx_leb window symbol symbol_map symbol_map_plus
+              idx_map idx_map_plus idx_trie analysis_result spaced_list_intersect m rs e_0 r) ->
+         egraph_ok (snd res) /\ exists i', map.extends i' i_0 /\ egraph_sound_for_interpretation i' (snd res)).
   Proof.
-    intros Hok_0 Hsnd_0 Hrules.
+    unfold vc; intro e_0; cbn beta; intros Hok_0 Hsnd_0 Hrules.
     unfold Defs.run1iter.
     cbn [Mbind Mseq Mret StateMonad.state_monad].
     destruct (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus idx_map idx_map_plus idx_trie analysis_result window rs e_0) as [tries e0'] eqn:Hbt.
     cbn [build_tries] in Hbt. inversion Hbt as [ [Htries He0'] ]. subst e0'.
     cbn [max_id worklist_empty].
     clear Hbt Htries tries.
+    pose proof increment_epoch_preserves as Hiep; unfold vc in Hiep; specialize (Hiep e_0).
     destruct (increment_epoch idx idx_succ symbol symbol_map idx_map idx_trie analysis_result e_0) as [u1 e_1] eqn:Hie.
-    pose proof (increment_epoch_preserves e_0) as [Hok1f Hs1f].
-    rewrite Hie in Hok1f, Hs1f. cbn [snd] in Hok1f, Hs1f.
+    cbn [fst snd] in Hiep. destruct Hiep as [Hok1f Hs1f].
     specialize (Hok1f Hok_0).
     set (db_tries := fst (build_tries idx Eqb_idx idx_succ idx_leb symbol symbol_map symbol_map_plus idx_map idx_map_plus idx_trie analysis_result window rs e_0)).
     change (map_intersect (build_tries_for_symbol idx Eqb_idx idx_succ idx_leb idx_map idx_map_plus idx_trie analysis_result (epoch e_0) window) (query_clauses idx symbol symbol_map idx_map rs) (db e_0)) with db_tries.
@@ -168,9 +170,12 @@ Section Slice.
         assert (Hin : In r (r :: rules')) by (left; reflexivity).
         pose proof (Hrh r Hin) as Hrhr.
         destruct Hrhr as (Hnd_qv & Hnd_wv & Hrule & Hwf & Hcov & Hdisj & HcovC & HcovU & Hlen & Hsli).
-        pose proof (@process_erule_sound idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero idx_leb symbol Eqb_symbol Eqb_symbol_ok symbol_map symbol_map_plus symbol_map_plus_ok symbol_map_ok idx_map idx_map_plus idx_map_ok idx_trie idx_trie_ok analysis_result idx_map_plus_ok spaced_list_intersect H m Hm Hlti Hlts Hltt window i_0 i_cur e_0 rs r e_cur Hsnd_0 Hok_cur Hsnd_cur Hext_cur Hnd_qv Hnd_wv Hrule Hwf Hcov Hdisj HcovC HcovU Hlen Hsli) as Hpe.
+        pose proof (@process_erule_sound idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero idx_leb symbol Eqb_symbol Eqb_symbol_ok symbol_map symbol_map_plus symbol_map_plus_ok symbol_map_ok idx_map idx_map_plus idx_map_ok idx_trie idx_trie_ok analysis_result idx_map_plus_ok spaced_list_intersect H m Hm Hlti Hlts Hltt window i_0 i_cur e_0 rs r Hsnd_0 Hnd_qv Hnd_wv Hrule Hwf Hcov Hdisj HcovC HcovU Hlen Hsli) as Hpe.
+        unfold vc in Hpe; specialize (Hpe e_cur).
         fold db_tries in Hpe.
         destruct (process_erule idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result spaced_list_intersect db_tries r e_cur) as [u e_mid] eqn:Hpe_eq.
+        cbn [fst snd] in Hpe.
+        specialize (Hpe Hok_cur Hsnd_cur Hext_cur).
         destruct Hpe as (Hok_mid & i_mid & Hext_mid & Hsnd_mid).
         assert (Hrh' : forall r0, In r0 rules' -> run1iter_rule_hyps idx Eqb_idx idx_zero idx_succ idx_leb window symbol symbol_map symbol_map_plus
                                                      idx_map idx_map_plus idx_trie analysis_result spaced_list_intersect m rs e_0 r0) by (intros r0 Hr0; apply Hrh; right; exact Hr0).
@@ -181,10 +186,11 @@ Section Slice.
     pose proof (Hloop (compiled_rules idx symbol symbol_map idx_map rs) e_1 i_0 Hrules Hok1f Hsnd_1 Hrefl) as Hrl.
     destruct (list_Miter (process_erule idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result spaced_list_intersect db_tries) (compiled_rules idx symbol symbol_map idx_map rs) e_1) as [u_loop e_2] eqn:Hlm.
     destruct Hrl as (Hok_2 & i_2 & Hext_2 & Hsnd_2).
-    pose proof (@rebuild_sound idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol Eqb_symbol Eqb_symbol_ok symbol_map symbol_map_ok idx_map idx_map_ok idx_trie idx_trie_ok analysis_result H m Hm (fun _ => True) rebuild_fuel e_2) as Hrb.
-    specialize (Hrb Hok_2). destruct Hrb as (Hok_3 & Hde).
+    pose proof (@rebuild_sound idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol Eqb_symbol Eqb_symbol_ok symbol_map symbol_map_ok idx_map idx_map_ok idx_trie idx_trie_ok analysis_result H m Hm rebuild_fuel) as Hrb.
+    unfold vc in Hrb; specialize (Hrb e_2).
     destruct (rebuild rebuild_fuel e_2) as [u3 e_3] eqn:Hrbeq.
-    cbn [snd] in Hok_3, Hde.
+    cbn [fst snd] in Hrb.
+    specialize (Hrb Hok_2). destruct Hrb as (Hok_3 & Hde).
     split; [exact Hok_3|].
     exists i_2. split; [exact Hext_2|].
     apply (proj1 (Hde i_2)). exact Hsnd_2.
@@ -205,14 +211,15 @@ Section Slice.
        run1iter_rule_hyps idx Eqb_idx idx_zero idx_succ idx_leb w symbol symbol_map symbol_map_plus
          idx_map idx_map_plus idx_trie analysis_result spaced_list_intersect m rs e r)
     (fuel : nat) :
-    forall (window : nat) (i_0 : idx_map (domain symbol m)) (e_0 : instance),
-    egraph_ok e_0 ->
-    egraph_sound_for_interpretation i_0 e_0 ->
-    match Defs.saturate_until' idx_succ idx_zero idx_leb spaced_list_intersect rebuild_fuel window rs P fuel e_0 with
-    | (_, e') => egraph_ok e' /\ exists i', map.extends i' i_0 /\ egraph_sound_for_interpretation i' e'
-    end.
+    forall (window : nat) (i_0 : idx_map (domain symbol m)),
+    vc (Defs.saturate_until' idx_succ idx_zero idx_leb spaced_list_intersect rebuild_fuel window rs P fuel)
+      (fun e_0 res =>
+         egraph_ok e_0 ->
+         egraph_sound_for_interpretation i_0 e_0 ->
+         egraph_ok (snd res) /\ exists i', map.extends i' i_0 /\ egraph_sound_for_interpretation i' (snd res)).
   Proof.
-    induction fuel as [|fuel IH]; intros window i_0 e_0 Hok_0 Hsnd_0.
+    induction fuel as [|fuel IH]; intros window i_0;
+      unfold vc; intro e_0; cbn beta; intros Hok_0 Hsnd_0.
     - cbn [Defs.saturate_until' Mret StateMonad.state_monad].
       split; [exact Hok_0|]. exists i_0. split; [apply Properties.map.extends_refl | exact Hsnd_0].
     - cbn [Defs.saturate_until'].
@@ -222,13 +229,19 @@ Section Slice.
       cbn [snd] in HokP, HsndP.
       destruct doneP.
       { split; [exact HokP|]. exists i_0. split; [apply Properties.map.extends_refl | exact HsndP]. }
-      pose proof (run1iter_sound Hlti Hlts Hltt rebuild_fuel window i_0 rs eP HokP HsndP (fun r Hr => Hrules window eP r Hr)) as Hri.
+      pose proof (run1iter_sound Hlti Hlts Hltt rebuild_fuel window i_0 rs) as Hri.
+      unfold vc in Hri; specialize (Hri eP).
       destruct (Defs.run1iter idx Eqb_idx idx_succ idx_zero idx_leb symbol symbol_map symbol_map_plus idx_map idx_map_plus idx_trie analysis_result spaced_list_intersect rebuild_fuel window rs eP) as [nc e2] eqn:Hru.
+      cbn [fst snd] in Hri.
+      specialize (Hri HokP HsndP (fun r Hr => Hrules window eP r Hr)).
       destruct Hri as (Hok2 & i_1 & Hext1 & Hsnd2).
       destruct nc.
       { split; [exact Hok2|]. exists i_1. split; [exact Hext1 | exact Hsnd2]. }
-      pose proof (IH 0 i_1 e2 Hok2 Hsnd2) as HIH.
+      pose proof (IH 0 i_1) as HIH.
+      unfold vc in HIH; specialize (HIH e2).
       destruct (saturate_until' idx_succ idx_zero idx_leb spaced_list_intersect rebuild_fuel 0 rs P fuel e2) as [b e_final] eqn:Hsat.
+      cbn [fst snd] in HIH.
+      specialize (HIH Hok2 Hsnd2).
       destruct HIH as (Hok_final & i_f & Hext_f & Hsnd_final).
       split; [exact Hok_final|]. exists i_f.
       split; [eapply map_extends_trans; [exact Hext_f | exact Hext1] | exact Hsnd_final].
@@ -273,28 +286,32 @@ Lemma saturate_until_sound
      run1iter_rule_hyps idx Eqb_idx idx_zero idx_succ idx_leb w symbol symbol_map symbol_map_plus
        idx_map idx_map_plus idx_trie analysis_result spaced_list_intersect m rs e r)
   (fuel : nat)
-  (i_0 : idx_map (domain symbol m)) (e_0 : Defs.instance idx symbol symbol_map idx_map idx_trie analysis_result) :
-  Semantics.egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result e_0 ->
-  Semantics.egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i_0 e_0 ->
-  match Defs.saturate_until idx_succ idx_zero idx_leb spaced_list_intersect rebuild_fuel window rs P fuel e_0 with
-  | (_, e') => Semantics.egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result e'
-               /\ exists i', map.extends i' i_0 /\ Semantics.egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i' e'
-  end.
+  (i_0 : idx_map (domain symbol m)) :
+  vc (Defs.saturate_until idx_succ idx_zero idx_leb spaced_list_intersect rebuild_fuel window rs P fuel)
+    (fun e_0 res =>
+       Semantics.egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result e_0 ->
+       Semantics.egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i_0 e_0 ->
+       Semantics.egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result (snd res)
+       /\ exists i', map.extends i' i_0 /\ Semantics.egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i' (snd res)).
 Proof.
-  intros Hok_0 Hsnd_0.
+  unfold vc; intro e_0; cbn beta; intros Hok_0 Hsnd_0.
   unfold Defs.saturate_until.
   cbn [Mseq Mbind StateMonad.state_monad].
   pose proof (Hconst e_0 i_0 Hok_0 Hsnd_0) as Hc.
   destruct (process_const_rules idx Eqb_idx idx_succ idx_zero symbol symbol_map idx_map idx_trie analysis_result rs e_0) as [u_c e_a] eqn:Hpc.
   cbn [snd] in Hc.
   destruct Hc as (Hok_a & i_a & Hext_a & Hsnd_a).
-  pose proof (@rebuild_sound idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol Eqb_symbol Eqb_symbol_ok symbol_map symbol_map_ok idx_map idx_map_ok idx_trie idx_trie_ok analysis_result H m Hm (fun _ => True) rebuild_fuel e_a) as Hrb.
-  specialize (Hrb Hok_a). destruct Hrb as (Hok_b & Hde).
+  pose proof (@rebuild_sound idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol Eqb_symbol Eqb_symbol_ok symbol_map symbol_map_ok idx_map idx_map_ok idx_trie idx_trie_ok analysis_result H m Hm rebuild_fuel) as Hrb.
+  unfold vc in Hrb; specialize (Hrb e_a).
   destruct (rebuild rebuild_fuel e_a) as [u_b e_b] eqn:Hrbeq.
-  cbn [snd] in Hok_b, Hde.
+  cbn [fst snd] in Hrb.
+  specialize (Hrb Hok_a). destruct Hrb as (Hok_b & Hde).
   pose proof (proj1 (Hde i_a) Hsnd_a) as Hsnd_b.
-  pose proof (saturate_until'_sound (spaced_list_intersect:=spaced_list_intersect) (m:=m) Hlti Hlts Hltt rebuild_fuel rs P HP Hrules fuel window i_a e_b Hok_b Hsnd_b) as Hsat.
+  pose proof (saturate_until'_sound (spaced_list_intersect:=spaced_list_intersect) (m:=m) Hlti Hlts Hltt rebuild_fuel rs P HP Hrules fuel window i_a) as Hsat.
+  unfold vc in Hsat; specialize (Hsat e_b).
   destruct (saturate_until' idx_succ idx_zero idx_leb spaced_list_intersect rebuild_fuel window rs P fuel e_b) as [b e_final] eqn:Hsf.
+  cbn [fst snd] in Hsat.
+  specialize (Hsat Hok_b Hsnd_b).
   destruct Hsat as (Hok_f & i_f & Hext_f & Hsnd_f).
   split; [exact Hok_f|]. exists i_f.
   split; [eapply map_extends_trans; [exact Hext_f | exact Hext_a] | exact Hsnd_f].

--- a/src/Utils/EGraph/SemanticsUnionSem.v
+++ b/src/Utils/EGraph/SemanticsUnionSem.v
@@ -206,22 +206,21 @@ Lemma exec_clause_sound
   (analysis_result : Type) (Hanalysis : analysis idx symbol analysis_result) (m : model symbol)
   (Hm : model_ok symbol m)
   (i : idx_map (domain symbol m))
-  (env : idx_map idx) (c : atom idx symbol) (a_src : idx_map (domain symbol m))
-  (e : Defs.instance idx symbol symbol_map idx_map idx_trie analysis_result) :
-  Semantics.egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result e ->
-  Semantics.egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i e ->
-  (forall x, In x (c.(atom_ret) :: c.(atom_args)) ->
-     exists v, map.get env x = Some v
-               /\ Sep.has_key v (parent (equiv e))
-               /\ map.get i v = map.get a_src x) ->
-  atom_sound_for_model idx symbol idx_map m a_src c ->
-  match exec_clause idx Eqb_idx idx_zero symbol symbol_map idx_map idx_trie analysis_result env c e with
-  | (_, e') =>
-      Semantics.egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result e'
-      /\ Semantics.egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i e'
-      /\ (forall z, Sep.has_key z (parent (equiv e)) -> Sep.has_key z (parent (equiv e')))
-  end.
+  (env : idx_map idx) (c : atom idx symbol) (a_src : idx_map (domain symbol m)) :
+  vc (exec_clause idx Eqb_idx idx_zero symbol symbol_map idx_map idx_trie analysis_result env c)
+    (fun e res =>
+       Semantics.egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result e ->
+       Semantics.egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i e ->
+       (forall x, In x (c.(atom_ret) :: c.(atom_args)) ->
+          exists v, map.get env x = Some v
+                    /\ Sep.has_key v (parent (equiv e))
+                    /\ map.get i v = map.get a_src x) ->
+       atom_sound_for_model idx symbol idx_map m a_src c ->
+       Semantics.egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result (snd res)
+       /\ Semantics.egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i (snd res)
+       /\ (forall z, Sep.has_key z (parent (equiv e)) -> Sep.has_key z (parent (equiv (snd res))))).
 Proof.
+  unfold vc; intros e.
   intros Hok Hsound Henv Hatom_src.
   unfold exec_clause.
   cbn [Mbind Mret StateMonad.state_monad].
@@ -337,19 +336,23 @@ Lemma union_extends_keys_sem
   (idx_map : forall A, map.map idx A) (idx_map_ok : forall A, map.ok (idx_map A))
   (idx_trie : forall A, map.map (list idx) A) (analysis_result : Type)
   (Hanalysis : analysis idx symbol analysis_result)
-  (x y : idx) (e_in : Defs.instance idx symbol symbol_map idx_map idx_trie analysis_result)
-  (Hroots_in : exists roots, union_find_ok lt (equiv e_in) roots)
-  (Hkx : Sep.has_key x (parent (equiv e_in)))
-  (Hky : Sep.has_key y (parent (equiv e_in)))
-  (z : idx)
-  (Hz : Sep.has_key z (parent (equiv e_in)))
-  : Sep.has_key z (parent (equiv (snd (Defs.union x y e_in)))).
+  (x y : idx)
+  : vc (Defs.union x y)
+      (fun e_in res =>
+         (exists roots, union_find_ok lt (equiv e_in) roots) ->
+         Sep.has_key x (parent (equiv e_in)) ->
+         Sep.has_key y (parent (equiv e_in)) ->
+         forall z,
+           Sep.has_key z (parent (equiv e_in)) ->
+           Sep.has_key z (parent (equiv (snd res)))).
 Proof.
-  destruct Hroots_in as [roots Hroots].
+  unfold vc; intros e_in.
   pose proof (union_sound idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol symbol_map idx_map idx_map_ok idx_trie analysis_result x y) as Hus.
   unfold vc in Hus. specialize (Hus e_in).
   destruct (Defs.union x y e_in) as [v_u e_u] eqn:Hu.
   cbn [snd] in Hus |- *.
+  intros Hroots_in Hkx Hky z Hz.
+  destruct Hroots_in as [roots Hroots].
   destruct (Hus (ex_intro _ roots Hroots) Hkx Hky) as
     (_ & Hroots' & Hper & _).
   destruct Hroots' as [roots' Hroots'].
@@ -377,16 +380,20 @@ Lemma union_preserves_egraph_ok_sem
   (idx_map : forall A, map.map idx A) (idx_map_ok : forall A, map.ok (idx_map A))
   (idx_trie : forall A, map.map (list idx) A) (analysis_result : Type)
   (Hanalysis : analysis idx symbol analysis_result)
-  (x y : idx) (e_in : Defs.instance idx symbol symbol_map idx_map idx_trie analysis_result)
-  (Hok_in : Semantics.egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result e_in)
-  (Hkx : Sep.has_key x (parent (equiv e_in)))
-  (Hky : Sep.has_key y (parent (equiv e_in)))
-  : Semantics.egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result (snd (Defs.union x y e_in)).
+  (x y : idx)
+  : vc (Defs.union x y)
+      (fun e_in res =>
+         Semantics.egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result e_in ->
+         Sep.has_key x (parent (equiv e_in)) ->
+         Sep.has_key y (parent (equiv e_in)) ->
+         Semantics.egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result (snd res)).
 Proof.
+  unfold vc; intros e_in.
   pose proof (union_sound idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol symbol_map idx_map idx_map_ok idx_trie analysis_result x y) as Hus.
   unfold vc in Hus. specialize (Hus e_in).
   destruct (Defs.union x y e_in) as [v_u e_u] eqn:Hu.
   cbn [snd] in Hus |- *.
+  intros Hok_in Hkx Hky.
   destruct Hok_in as [Heqok Hwlok Hparok Hdbkok].
   destruct Heqok as [roots Hroots].
   destruct (Hus (ex_intro _ roots Hroots) Hkx Hky) as
@@ -463,18 +470,22 @@ Lemma union_preserves_sound_sem
   (Hanalysis : analysis idx symbol analysis_result) (m : model symbol)
   (Hm : model_ok symbol m)
   (x y : idx)
-  (i0 : idx_map (domain symbol m)) (e_in : Defs.instance idx symbol symbol_map idx_map idx_trie analysis_result)
-  (Hok_in : Semantics.egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result e_in)
-  (Hsnd_in : Semantics.egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i0 e_in)
-  (Hkx : Sep.has_key x (parent (equiv e_in)))
-  (Hky : Sep.has_key y (parent (equiv e_in)))
-  (Heq_xy : eq_sound_for_model idx symbol idx_map m i0 x y)
-  : Semantics.egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i0 (snd (Defs.union x y e_in)).
+  (i0 : idx_map (domain symbol m))
+  : vc (Defs.union x y)
+      (fun e_in res =>
+         Semantics.egraph_ok idx lt symbol symbol_map idx_map idx_trie analysis_result e_in ->
+         Semantics.egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i0 e_in ->
+         Sep.has_key x (parent (equiv e_in)) ->
+         Sep.has_key y (parent (equiv e_in)) ->
+         eq_sound_for_model idx symbol idx_map m i0 x y ->
+         Semantics.egraph_sound_for_interpretation idx symbol symbol_map idx_map idx_trie analysis_result m i0 (snd res)).
 Proof.
+  unfold vc; intros e_in.
   pose proof (union_sound idx Eqb_idx Eqb_idx_ok lt idx_succ idx_zero symbol symbol_map idx_map idx_map_ok idx_trie analysis_result x y) as Hus.
   unfold vc in Hus. specialize (Hus e_in).
   destruct (Defs.union x y e_in) as [v_u e_u] eqn:Hu.
   cbn [snd] in Hus |- *.
+  intros Hok_in Hsnd_in Hkx Hky Heq_xy.
   destruct Hok_in as [Heqok Hwlok Hparok Hdbkok].
   destruct Heqok as [roots Hroots].
   destruct (Hus (ex_intro _ roots Hroots) Hkx Hky) as


### PR DESCRIPTION
Refactor all proofs under Utils/EGraph so that every lemma characterizing a state-monad computation is stated with the `vc` combinator (Utils/VC.v) instead of being written out with raw primitives (`match c e with (_,e')`, `snd (c e)`, `c e = (a,e')`), and remove unused lemma arguments.